### PR TITLE
[#45][#51] 일정 상세조회, 초대코드 입력, 팀 목록 페이지 css, js 수정 & leader일 경우 초대코드 보이게 구현

### DIFF
--- a/src/main/java/com/example/omg_project/domain/trip/controller/TripApiController.java
+++ b/src/main/java/com/example/omg_project/domain/trip/controller/TripApiController.java
@@ -102,7 +102,7 @@ public class TripApiController {
         }
     }
 
-    //tripId로 일정 조회t
+    //tripId로 일정 조회
     @GetMapping("/{id}")
     public ResponseEntity<ReadTripDTO> getTripById(@PathVariable Long id) {
         ReadTripDTO trip = tripService.getTripById(id);

--- a/src/main/java/com/example/omg_project/domain/trip/service/TeamService.java
+++ b/src/main/java/com/example/omg_project/domain/trip/service/TeamService.java
@@ -18,4 +18,5 @@ public interface TeamService {
     void addUserToTeam(String inviteCode, Long userId);
 
     Team findByChatRoomId(Long chatRoomId);
+
 }

--- a/src/main/java/com/example/omg_project/domain/trip/service/impl/TeamServiceImpl.java
+++ b/src/main/java/com/example/omg_project/domain/trip/service/impl/TeamServiceImpl.java
@@ -77,6 +77,10 @@ public class TeamServiceImpl implements TeamService {
                     boolean isLeader = team.getLeader().getId().equals(userId);
                     teamData.put("isLeader", isLeader);
 
+                    if (isLeader) {
+                        teamData.put("inviteCode", team.getInviteCode());
+                    }
+
                     return teamData;
                 })
                 .collect(Collectors.toList());

--- a/src/main/resources/templates/team/join.html
+++ b/src/main/resources/templates/team/join.html
@@ -4,12 +4,76 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>팀에 가입하기</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f7f7f7;
+            color: #333;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            box-sizing: border-box;
+        }
+
+        h1 {
+            font-size: 22px;
+            font-weight: bold;
+            color: #1981ff;
+            margin-bottom: 20px;
+        }
+
+        form {
+            background-color: #ffffff;
+            padding: 20px;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            max-width: 500px;
+            width: 100%;
+            box-sizing: border-box;
+        }
+
+        label {
+            font-size: 16px;
+            color: #333;
+        }
+
+        input[type="text"] {
+            width: 100%;
+            padding: 10px;
+            margin-top: 5px;
+            margin-bottom: 20px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            box-sizing: border-box;
+            font-size: 16px;
+        }
+
+        button {
+            padding: 10px 20px;
+            border: none;
+            border-radius: 25px;
+            background-color: #8fc6ff;
+            color: white;
+            cursor: pointer;
+            font-size: 16px;
+            transition: background-color 0.3s ease;
+            width: 100%;
+        }
+
+        button:hover {
+            background-color: #0a74e5;
+        }
+    </style>
 </head>
 <body>
-<h1>초대 코드를 입력하여 팀에 가입하세요</h1>
+
 <form id="joinTeamForm">
-    <label for="inviteCode">초대 코드:</label>
-    <input type="text" id="inviteCode" name="inviteCode" required>
+    <h1>초대 코드를 입력하여 여행 일정에 참여해보세요 😀</h1>
+    <input type="text" id="inviteCode" name="inviteCode" placeholder="초대코드를 입력해주세요" required>
     <br><br>
     <button type="submit">가입하기</button>
 </form>

--- a/src/main/resources/templates/team/join.html
+++ b/src/main/resources/templates/team/join.html
@@ -97,6 +97,7 @@
 
             if (response.ok) {
                 alert(`${result}`);
+                window.location.href = '/';
             } else {
                 alert(`${result}`);
             }

--- a/src/main/resources/templates/team/myteam.html
+++ b/src/main/resources/templates/team/myteam.html
@@ -71,7 +71,7 @@
             background-color: #ff6b6b;
             color: white;
             cursor: pointer;
-            font-size: 14px;
+            font-size: 13px;
             transition: background-color 0.3s ease;
         }
 

--- a/src/main/resources/templates/team/myteam.html
+++ b/src/main/resources/templates/team/myteam.html
@@ -3,10 +3,81 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>가입된 팀 목록</title>
+    <title>팀 목록 관리</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #f1f1f1;
+            color: #333;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            min-height: 100vh;
+            box-sizing: border-box;
+        }
+
+        h1 {
+            font-size: 25px; /* 제목 크기 확대 */
+            font-weight: bold;
+            color: #000000;
+            margin-bottom: 30px; /* 제목과 목록 사이의 간격 증가 */
+            align-self: flex-start; /* 제목을 왼쪽 정렬 */
+            margin-left: calc(50% - 300px); /* 리스트와 일치하도록 왼쪽 정렬 */
+        }
+
+        ul#teamList {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+            width: 100%;
+            max-width: 600px;
+        }
+
+        ul#teamList li {
+            background-color: #ffffff;
+            margin-bottom: 10px;
+            padding: 15px;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        ul#teamList li:last-child {
+            margin-bottom: 0;
+        }
+
+        button {
+            padding: 8px 12px;
+            border: none;
+            border-radius: 15px;
+            background-color: #ff6b6b;
+            color: white;
+            cursor: pointer;
+            font-size: 14px;
+            transition: background-color 0.3s ease;
+        }
+
+        button:hover {
+            background-color: #e85858;
+        }
+
+        .leader-badge {
+            font-size: 12px;
+            color: #666;
+            font-weight: bold;
+            padding: 3px 6px;
+            background-color: #e0e0e0;
+            border-radius: 12px;
+            margin-left: 10px;
+        }
+    </style>
 </head>
 <body>
-<h1>가입된 팀 목록</h1>
+<br>
+<h1>나의 팀 목록</h1> <!-- 제목 변경 -->
 <ul id="teamList">
     <!-- 팀 목록 렌더링 -->
 </ul>
@@ -24,10 +95,9 @@
             const teamListElement = document.getElementById('teamList');
             teamListElement.innerHTML = '';  // 기존 목록을 지우고 새로 작성
 
-            // 팀 목록을
             teams.forEach(team => {
                 const listItem = document.createElement('li');
-                listItem.textContent = `팀 ID: ${team.id} -  ${team.tripName}`;
+                listItem.textContent = `팀 ID ${team.id} :  ${team.tripName}`;
 
                 // 리더가 아닌 경우에만 탈퇴 버튼을 표시
                 if (!team.isLeader) {
@@ -36,7 +106,10 @@
                     leaveButton.onclick = () => leaveTeam(team.id);
                     listItem.appendChild(leaveButton);
                 } else {
-                    listItem.textContent += ' (리더)';
+                    const leaderBadge = document.createElement('span');
+                    leaderBadge.textContent = '리더';
+                    leaderBadge.className = 'leader-badge';
+                    listItem.appendChild(leaderBadge);
                 }
 
                 teamListElement.appendChild(listItem);

--- a/src/main/resources/templates/team/myteam.html
+++ b/src/main/resources/templates/team/myteam.html
@@ -45,8 +45,23 @@
             align-items: center;
         }
 
-        ul#teamList li:last-child {
-            margin-bottom: 0;
+        .team-info {
+            display: flex;
+            justify-content: space-between;
+            width: 100%;
+            align-items: center;
+        }
+
+        .right-aligned {
+            display: flex;
+            align-items: center;
+            margin-left: auto; /* 오른쪽 정렬 */
+        }
+
+        .invite-code {
+            font-size: 14px;
+            color: #555;
+            margin-left: 10px;
         }
 
         button {
@@ -77,7 +92,7 @@
 </head>
 <body>
 <br>
-<h1>나의 팀 목록</h1> <!-- 제목 변경 -->
+<h1>나의 팀 목록</h1>
 <ul id="teamList">
     <!-- 팀 목록 렌더링 -->
 </ul>
@@ -97,21 +112,35 @@
 
             teams.forEach(team => {
                 const listItem = document.createElement('li');
-                listItem.textContent = `팀 ID ${team.id} :  ${team.tripName}`;
 
-                // 리더가 아닌 경우에만 탈퇴 버튼을 표시
+                const teamInfo = document.createElement('div');
+                teamInfo.textContent = `팀 ID ${team.id} : ${team.tripName}`;
+
+                const rightAligned = document.createElement('div');
+                rightAligned.className = 'right-aligned';
+
                 if (!team.isLeader) {
                     const leaveButton = document.createElement('button');
                     leaveButton.textContent = '탈퇴하기';
                     leaveButton.onclick = () => leaveTeam(team.id);
-                    listItem.appendChild(leaveButton);
+                    rightAligned.appendChild(leaveButton);
                 } else {
                     const leaderBadge = document.createElement('span');
                     leaderBadge.textContent = '리더';
                     leaderBadge.className = 'leader-badge';
-                    listItem.appendChild(leaderBadge);
+                    rightAligned.appendChild(leaderBadge);
+
+                    // 리더에게 초대 코드를 표시
+                    if (team.inviteCode) {
+                        const inviteCodeElement = document.createElement('div');
+                        inviteCodeElement.className = 'invite-code';
+                        inviteCodeElement.textContent = `초대 코드: ${team.inviteCode}`;
+                        rightAligned.appendChild(inviteCodeElement);
+                    }
                 }
 
+                listItem.appendChild(teamInfo);
+                listItem.appendChild(rightAligned);
                 teamListElement.appendChild(listItem);
             });
 

--- a/src/main/resources/templates/trip/viewtripdetails.html
+++ b/src/main/resources/templates/trip/viewtripdetails.html
@@ -5,47 +5,213 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>여행 일정 상세 조회</title>
     <link rel="stylesheet" href="/css/trip.css">
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            background-color: #ffffff;
+            color: #333;
+            display: flex;
+            min-height: 100vh;
+            box-sizing: border-box;
+            max-width: 1200px; /* 바디의 최대 너비 설정 */
+            margin: auto; /* 바디를 중앙으로 정렬 */
+        }
+
+        .sidebar {
+            width: 200px;
+            padding: 20px;
+            background-color: #f8f9fa;
+            height: 100vh;
+            box-sizing: border-box;
+        }
+
+        .sidebar button {
+            display: block;
+            width: 100%;
+            margin-bottom: 10px;
+            padding: 10px;
+            background-color: #8fc6ff;
+            border: none;
+            border-radius: 15px;
+            cursor: pointer;
+            text-align: left;
+        }
+
+        .sidebar button:hover {
+            background-color: #519ace;
+        }
+
+        .content {
+            flex: 1;
+            padding: 20px;
+        }
+
+        .header {
+            margin-bottom: 20px;
+            text-align: left;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        h1 {
+            font-size: 36px;
+            font-weight: bold;
+            color: #333;
+            margin-right: 20px;
+        }
+
+        .button-group {
+            display: flex;
+            gap: 10px;
+        }
+
+        button {
+            padding: 8px 12px;
+            border: none;
+            border-radius: 15px;
+            background-color: #8fc6ff;
+            color: white;
+            cursor: pointer;
+            font-size: 14px;
+            transition: background-color 0.3s ease;
+            display: inline-block;
+        }
+
+        button:hover {
+            background-color: #519ace;
+        }
+
+        #deleteButton {
+            background-color: #8fc6ff;
+        }
+
+        #deleteButton:hover {
+            background-color: #519ace;
+        }
+
+        p {
+            font-size: 18px;
+            color: #666;
+            margin-bottom: 10px;
+        }
+
+        .trip-detail {
+            display: flex;
+            flex-wrap: wrap;
+            background-color: transparent;
+            box-sizing: border-box;
+        }
+
+        .day-column {
+            flex: 1;
+            margin-right: 20px;
+            background-color: #ffffff;
+            padding: 15px;
+            border-radius: 0;
+            box-shadow: none;
+            border: none;
+            display: none; /* 기본적으로 모든 일정은 숨겨둠 */
+        }
+
+        .day-column.active {
+            display: block; /* 선택된 일정만 보이도록 설정 */
+        }
+
+        .day-column:last-child {
+            margin-right: 0;
+        }
+
+        .day-title {
+            font-size: 24px;
+            color: #007bff;
+            margin-bottom: 15px;
+            font-weight: bold;
+        }
+
+        ul {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+            margin-bottom: 20px;
+        }
+
+        ul li {
+            font-size: 17px;
+            color: #333;
+            margin-bottom: 10px;
+            padding-left: 10px;
+            border-left: 3px solid #4b4b4b;
+            line-height: 1.5;
+        }
+    </style>
 </head>
 <body>
 
-<div class="trip-detail">
-    <input type="hidden" id="tripId" th:value="${trip.id}">
-    <input type="hidden" id="currentUserId" th:value="${currentUserId}">
-    <input type="hidden" id="leaderId" th:value="${leaderId}">
+<div class="sidebar">
+    <button onclick="showDay('all')">전체 일정</button>
+    <div th:each="date, iterStat : ${trip.tripDates}">
+        <button th:text="'Day ' + (${iterStat.index + 1})"
+                th:onclick="'showDay(\'day' + (${iterStat.index + 1}) + '\')'">
+            1일차
+        </button>
+    </div>
+</div>
 
-    <h1>여행 일정 상세 조회</h1>
-    <h2 th:text="${trip.tripName}">여행 이름</h2>
-    <p>시작 날짜: <span th:text="${trip.startDate}">시작 날짜</span></p>
-    <p>종료 날짜: <span th:text="${trip.endDate}">종료 날짜</span></p>
-    <p>도시 이름: <span th:text="${trip.city.name}">도시 이름</span></p>
-    <h3>여행 일정</h3>
-    <div th:each="date : ${trip.tripDates}">
-        <h4 th:text="${date.tripDate}">여행 날짜</h4>
-        <ul>
-            <li th:each="location : ${date.tripLocations}">
-                <span th:text="${location.placeName}">장소 이름</span> (위도: <span th:text="${location.latitude}">위도</span>, 경도: <span th:text="${location.longitude}">경도</span>)
-            </li>
-        </ul>
+<div class="content">
+    <div class="header">
+        <div>
+            <h1 th:text="${trip.tripName}">여행 이름</h1>
+            <input type="hidden" id="tripId" th:value="${trip.id}">
+            <span th:text="${trip.city.name}">도시 이름</span>
+            <span th:text="${trip.startDate} + ' - ' + ${trip.endDate}">시작 날짜 - 종료 날짜</span>
+        </div>
+        <div class="button-group" th:if="${currentUserId == leaderId}">
+            <button id="editButton">수정</button>
+            <button id="deleteButton">삭제</button>
+        </div>
     </div>
 
-    <div th:if="${currentUserId != leaderId}">
-        <button id="copyTripButton">내 일정으로 가져오기</button>
-    </div>
-
-    <div th:if="${currentUserId == leaderId}">
-        <button id="editButton">수정</button>
-        <button id="deleteButton">삭제</button>
+    <div class="trip-detail">
+        <div th:each="date, iterStat : ${trip.tripDates}" class="day-column" th:classappend="'day' + ${iterStat.index + 1}">
+            <div class="day-title">Day<span th:text="${iterStat.index + 1}"></span> <span th:text="${date.tripDate}">여행 날짜</span></div>
+            <ul>
+                <li th:each="location : ${date.tripLocations}">
+                    <span th:text="${location.placeName}">장소 이름</span>
+                </li>
+            </ul>
+        </div>
     </div>
 </div>
 
 <script>
+    function showDay(day) {
+        var dayColumns = document.querySelectorAll('.day-column');
+
+        dayColumns.forEach(function(column) {
+            if (day === 'all') {
+                column.classList.add('active');
+            } else {
+                column.classList.remove('active');
+                if (column.classList.contains(day)) {
+                    column.classList.add('active');
+                }
+            }
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', function() {
-        var tripId = document.getElementById('tripId').value;
-        var copyTripButton = document.getElementById('copyTripButton');
+        var tripIdElement = document.getElementById('tripId');
+        var tripId = tripIdElement ? tripIdElement.value : null;
+
+        if (!tripId) {
+            console.error('Trip ID is missing');
+            return;
+        }
+
         var editButton = document.getElementById('editButton');
         var deleteButton = document.getElementById('deleteButton');
-
-        console.log('Trip ID:', tripId); // 디버깅을 위한 콘솔 출력
 
         if (deleteButton) {
             deleteButton.addEventListener('click', function() {
@@ -59,7 +225,7 @@
                         .then(response => {
                             if (response.ok) {
                                 alert('삭제되었습니다.');
-                                window.location.href = '/'; // 삭제 후 목록 페이지로 리다이렉트
+                                window.location.href = '/';
                             } else {
                                 alert('삭제 중 오류가 발생했습니다.');
                             }
@@ -74,32 +240,11 @@
 
         if (editButton) {
             editButton.addEventListener('click', function() {
-                window.location.href = `/trip/update/${tripId}`; // 수정 페이지로 리다이렉트
+                window.location.href = `/trip/update/${tripId}`;
             });
         }
 
-        if (copyTripButton) {
-            copyTripButton.addEventListener('click', function() {
-                fetch(`/api/trips/${tripId}/copy`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    }
-                })
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.message) {
-                            alert(data.message);
-                        } else {
-                            alert('여행 일정 저장 중 오류가 발생했습니다.');
-                        }
-                    })
-                    .catch(error => {
-                        console.error('Error copying trip:', error);
-                        alert('여행 일정 저장 중 오류가 발생했습니다.');
-                    });
-            });
-        }
+        showDay('all'); // 페이지 로드 시 전체 일정을 표시
     });
 </script>
 </body>

--- a/src/main/resources/templates/trip/viewtripdetails.html
+++ b/src/main/resources/templates/trip/viewtripdetails.html
@@ -173,6 +173,7 @@
         </div>
     </div>
 
+    <br>
     <div class="trip-detail">
         <div th:each="date, iterStat : ${trip.tripDates}" class="day-column" th:classappend="'day' + ${iterStat.index + 1}">
             <div class="day-title">Day<span th:text="${iterStat.index + 1}"></span> <span th:text="${date.tripDate}">여행 날짜</span></div>


### PR DESCRIPTION
### 설명
- 일정 상세조회, 초대코드 입력, 팀 목록 페이지 css 수정하였습니다.
- 팀 목록 페이지에서 특정 팀의 리더일 경우 그 팀의 초대코드가 보이도록 수정하였습니다.

### 관련 이슈
Closes #45
Closes #51

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트

### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.

### 추가 설명
- localhost:8080/team/myteam 
- 특정 팀의 리더일 경우 그 팀의 초대코드가 보임
- 리더가 아닐 경우 탈퇴하기 버튼이 보임
