### PR TITLE
[#63] 조회 username 비교 부분 jwt 토큰 파싱으로 변경, 컨트롤러에 user 객체 담기

### DIFF
--- a/src/main/java/com/example/omg_project/domain/trip/controller/TeamController.java
+++ b/src/main/java/com/example/omg_project/domain/trip/controller/TeamController.java
@@ -19,7 +19,7 @@ public class TeamController {
     private final UserService userService;
     // 팀에 가입하는 폼
     @GetMapping("/join")
-    public String showJoinTeamForm(@RequestParam Model model, HttpServletRequest request) {
+    public String showJoinTeamForm(Model model, HttpServletRequest request) {
         String accessToken = jwtTokenizer.getAccessTokenFromCookies(request);
         String username = jwtTokenizer.getUsernameFromToken(accessToken);
         User user = userService.findByUsername(username).orElseThrow();
@@ -28,7 +28,7 @@ public class TeamController {
     }
 
     @GetMapping("/myteam")
-    public String showTeamsPage(@RequestParam Model model, HttpServletRequest request) {
+    public String showTeamsPage(Model model, HttpServletRequest request) {
         String accessToken = jwtTokenizer.getAccessTokenFromCookies(request);
         String username = jwtTokenizer.getUsernameFromToken(accessToken);
         User user = userService.findByUsername(username).orElseThrow();

--- a/src/main/java/com/example/omg_project/domain/trip/controller/TeamController.java
+++ b/src/main/java/com/example/omg_project/domain/trip/controller/TeamController.java
@@ -1,21 +1,38 @@
 package com.example.omg_project.domain.trip.controller;
 
+import com.example.omg_project.domain.user.entity.User;
+import com.example.omg_project.domain.user.service.UserService;
+import com.example.omg_project.global.jwt.util.JwtTokenizer;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/team")
+@RequiredArgsConstructor
 public class TeamController {
+    private final JwtTokenizer jwtTokenizer;
+    private final UserService userService;
     // 팀에 가입하는 폼
     @GetMapping("/join")
-    public String showJoinTeamForm() {
+    public String showJoinTeamForm(@RequestParam Model model, HttpServletRequest request) {
+        String accessToken = jwtTokenizer.getAccessTokenFromCookies(request);
+        String username = jwtTokenizer.getUsernameFromToken(accessToken);
+        User user = userService.findByUsername(username).orElseThrow();
+        model.addAttribute("user", user);
         return "team/join";
     }
 
     @GetMapping("/myteam")
-    public String showTeamsPage() {
+    public String showTeamsPage(@RequestParam Model model, HttpServletRequest request) {
+        String accessToken = jwtTokenizer.getAccessTokenFromCookies(request);
+        String username = jwtTokenizer.getUsernameFromToken(accessToken);
+        User user = userService.findByUsername(username).orElseThrow();
+        model.addAttribute("user", user);
         return "team/myteam";
     }
 }

--- a/src/main/java/com/example/omg_project/domain/trip/controller/TripController.java
+++ b/src/main/java/com/example/omg_project/domain/trip/controller/TripController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 
-import java.security.Principal;
 import java.util.List;
 
 @Controller
@@ -33,7 +32,11 @@ public class TripController {
 
     // 여행 일정 생성 페이지
     @GetMapping("/create")
-    public String createTripPage() {
+    public String createTripPage(Model model, HttpServletRequest request) {
+        String accessToken = jwtTokenizer.getAccessTokenFromCookies(request);
+        String username = jwtTokenizer.getUsernameFromToken(accessToken);
+        User user = userService.findByUsername(username).orElseThrow();
+        model.addAttribute("user", user);
         return "trip/createtrip";
     }
 
@@ -72,16 +75,25 @@ public class TripController {
 
     //사용자의 일정 리스트 표시
     @GetMapping("/user/{userId}")
-    public String viewTripsByUserIdPage(@PathVariable Long userId, Model model) {
+    public String viewTripsByUserIdPage(@PathVariable Long userId, Model model, HttpServletRequest request) {
         List<ReadTripDTO> trips = tripService.getTripsByUserId(userId);
+        String accessToken = jwtTokenizer.getAccessTokenFromCookies(request);
+        String username = jwtTokenizer.getUsernameFromToken(accessToken);
+        User user = userService.findByUsername(username).orElseThrow();
+        model.addAttribute("user", user);
         model.addAttribute("trips", trips);
+
         return "trip/usertrip";
     }
 
     //여행 일정 수정 페이지
     @GetMapping("/update/{id}")
-    public String showUpdateTripPage(@PathVariable Long id, Model model) {
+    public String showUpdateTripPage(@PathVariable Long id, Model model, HttpServletRequest request) {
         ReadTripDTO trip = tripService.getTripById(id);
+        String accessToken = jwtTokenizer.getAccessTokenFromCookies(request);
+        String username = jwtTokenizer.getUsernameFromToken(accessToken);
+        User user = userService.findByUsername(username).orElseThrow();
+        model.addAttribute("user", user);
         model.addAttribute("trip", trip);
         return "trip/updateTrip";
     }

--- a/src/main/java/com/example/omg_project/domain/trip/controller/TripController.java
+++ b/src/main/java/com/example/omg_project/domain/trip/controller/TripController.java
@@ -72,16 +72,25 @@ public class TripController {
 
     //사용자의 일정 리스트 표시
     @GetMapping("/user/{userId}")
-    public String viewTripsByUserIdPage(@PathVariable Long userId, Model model) {
+    public String viewTripsByUserIdPage(@PathVariable Long userId, Model model, HttpServletRequest request) {
         List<ReadTripDTO> trips = tripService.getTripsByUserId(userId);
+        String accessToken = jwtTokenizer.getAccessTokenFromCookies(request);
+        String username = jwtTokenizer.getUsernameFromToken(accessToken);
+        User user = userService.findByUsername(username).orElseThrow();
+        model.addAttribute("user", user);
         model.addAttribute("trips", trips);
+
         return "trip/usertrip";
     }
 
     //여행 일정 수정 페이지
     @GetMapping("/update/{id}")
-    public String showUpdateTripPage(@PathVariable Long id, Model model) {
+    public String showUpdateTripPage(@PathVariable Long id, Model model, HttpServletRequest request) {
         ReadTripDTO trip = tripService.getTripById(id);
+        String accessToken = jwtTokenizer.getAccessTokenFromCookies(request);
+        String username = jwtTokenizer.getUsernameFromToken(accessToken);
+        User user = userService.findByUsername(username).orElseThrow();
+        model.addAttribute("user", user);
         model.addAttribute("trip", trip);
         return "trip/updateTrip";
     }


### PR DESCRIPTION
### 설명
- 상세 조회 페이지에서 글 쓴 사용자와 로그인한 사용자를 간단하게 시큐리티를 사용해서 비교함 (수정/삭제 위해) -> jwt 토큰 파싱하여 비교하도록 수정
- 헤더 사용을 위해 TeamController, TripController에 user 객체 담아서 보내줌

### 관련 이슈
Closes #63

### 변경 유형
- [ ] 버그 수정
- [ ] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트

### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.

### 추가 설명

