### PR TITLE
여행 일정과 장소 인덱스, 지도 마커 표시, 선택 갯수 제한 구현

### DIFF
--- a/src/main/resources/static/css/map.css
+++ b/src/main/resources/static/css/map.css
@@ -173,12 +173,12 @@
     color: #777;
 }
 
-#searchBtn, #completeBtn {
+#searchBtn, #closeBtn {
     padding: 10px;
     margin-bottom: 5px;
 }
 
-#selectBtn, #removeBtn {
+#selectBtn {
     padding: 5px;
     margin-bottom: 5px;
 }

--- a/src/main/resources/static/css/trip.css
+++ b/src/main/resources/static/css/trip.css
@@ -130,6 +130,7 @@ span {
 
 .placeNameContainer span {
     padding-bottom: 10px;
+    font-weight: bold;
 }
 
 .placeNameContainer button {

--- a/src/main/resources/static/css/trip.css
+++ b/src/main/resources/static/css/trip.css
@@ -130,3 +130,14 @@ span {
 .placeNameContainer button {
     width: 22%;
 }
+
+.backLink {
+    display: inline-block;
+    margin-bottom: 20px;
+    color: #8fc6ff;
+    text-decoration: none;
+}
+
+.backLink:hover {
+    text-decoration: underline;
+}

--- a/src/main/resources/static/css/trip.css
+++ b/src/main/resources/static/css/trip.css
@@ -120,11 +120,16 @@ span {
 .placeNameContainer {
     display: flex;           /* flexbox 사용 */
     align-items: center;    /* 세로 중앙 정렬 */
-    gap: 10px;
+    justify-content: center;    /* 수평 중앙 정렬 */
+    gap: 7px;
 }
 
 .placeNameInput {
     flex: 1;                /* 입력 필드가 가능한 공간을 차지하도록 설정 */
+}
+
+.placeNameContainer span {
+    padding-bottom: 10px;
 }
 
 .placeNameContainer button {

--- a/src/main/resources/static/js/createtrip.js
+++ b/src/main/resources/static/js/createtrip.js
@@ -96,16 +96,6 @@ function sendPlaceData(places) {
 function handleSelectBtnClick(event, place, placePosition) {
     event.stopPropagation();    // 이벤트 버블링 방지
 
-    // selectedPlaces 배열의 각 요소 p의 id가 인자로 전달된 place의 id와 같은지 확인
-    // .some()은 배열의 각 요소에 대한 테스트 -> true 또는 false 반환
-    // const isAlreadySelected = selectedPlaces.some(p => p.id === place.id);
-
-    // 이미 선택된 장소인지 확인
-    // if (isAlreadySelected) {
-    //     alert('이미 선택된 장소입니다.');
-    //     return;
-    // }
-
     // addLocation에서 반환된 dayNum을 가져옴
     const dayNum = addLocation(selectedDateDiv);
 

--- a/src/main/resources/static/js/createtrip.js
+++ b/src/main/resources/static/js/createtrip.js
@@ -153,22 +153,29 @@ function handleSelectBtnClick(event, place, placePosition) {
 function handleRemoveBtnClick(event, placeUniqueId, placePositionLa, placePositionMa) {
     event.stopPropagation();
 
-    // uniqueId에서 dayNum과 placeIndex를 추출
-    const [dayNum, placeIndex] = placeUniqueId.split('-').map(Number);
+    // 클릭된 버튼
+    const button = event.target;
+
+    // 버튼의 부모 요소
+    const parentElement = button.parentElement;
+
+    // 부모 요소 내에서 형제 요소 중 span 태그 찾기
+    const spanElement = parentElement.querySelector('span');
+
+    // span 태그의 id에서 dayNum과 placeIndex 추출
+    const [dayNum, placeIndex] = spanElement.id.split('-').map(Number);
+    // const [, placeIndex] = spanElement.id.split('-').map(Number);
 
     // selectedPlaces에서 해당 날짜와 인덱스에 있는 장소를 삭제
     if (selectedPlaces[dayNum]) {
+        // console.log('placeIndex: ', placeIndex);
+        // console.log('selectedPlaces[dayNum].length: ', selectedPlaces[dayNum].length);
         // 인덱스가 유효한지 확인하고 해당 장소를 삭제
-        if (placeIndex <= selectedPlaces[dayNum].length && placeIndex > 0) {
+        // if (placeIndex <= selectedPlaces[dayNum].length && placeIndex > 0) {
             selectedPlaces[dayNum].splice(placeIndex - 1, 1); // 인덱스는 0부터 시작하므로 -1
 
             // placesContainer에서 해당 장소를 포함하는 element를 찾아서 삭제
-            const locationElements = document.querySelectorAll('.placeNameContainer');
-            locationElements.forEach(element => {
-                if (element.querySelector('span').id === placeUniqueId) {
-                    element.parentNode.remove(); // 해당 요소 삭제
-                }
-            });
+            parentElement.parentElement.remove();
 
             // markers 배열에서 해당 장소 위치에 해당하는 marker 요소 제거
             const tolerance = 0.00000001; // 허용 오차 범위 설정
@@ -184,14 +191,47 @@ function handleRemoveBtnClick(event, placeUniqueId, placePositionLa, placePositi
             if (markerIndex !== -1) {   // 해당 장소 위치의 마커가 존재한다면
                 markers[dayNum][markerIndex].setMap(null);  // 지도에서 마커 제거
                 markers[dayNum].splice(markerIndex, 1); // 배열에서 마커 제거. 인덱스부터 1개의 요소 삭제
-                reorderMarkers(markers[dayNum]);    // 마커 번호 재정렬
             }
-        } else {
-            console.error('장소 인덱스가 유효하지 않습니다.');
-        }
+
+            console.log('Selected Places:', selectedPlaces);
+            console.log('Markers:', markers);
+
+            // 장소와 마커가 삭제된 후, 나머지 요소들의 인덱스와 ID를 업데이트
+            updatePlaceIndexes(dayNum);
+            reorderMarkers(markers[dayNum]);    // 마커 번호 재정렬
+
+        // console.log('삭제 후 selectedPlaces[dayNum].length: ', selectedPlaces[dayNum].length);
+
+        // } else {
+        //     console.error('장소 인덱스가 유효하지 않습니다.');
+        // }
     } else {
         console.error('dayNum이 존재하지 않습니다.');
     }
+}
+
+
+/**
+ * 삭제 후 나머지 장소의 인덱스와 ID를 업데이트하는 함수
+ * @param dayNum - 선택된 날짜의 번호
+ */
+function updatePlaceIndexes(dayNum) {
+    // 해당 날짜의 모든 placeNameContainer 요소를 선택
+    const locationElements = document.querySelectorAll(`.tripDate:nth-child(${dayNum}) .dayLocation .placeNameContainer`);
+
+    // 각 placeNameContainer의 span 태그의 id와 내용을 업데이트
+    locationElements.forEach((placeNameContainer, index) => {
+        const spanElement = placeNameContainer.querySelector('span');
+        if (spanElement) {
+            console.log(`${dayNum}-${index + 1}`);
+            const newId = `${dayNum}-${index + 1}`;
+            spanElement.id = newId; // 새로운 id 설정
+            spanElement.textContent = index + 1; // 새로운 번호 설정
+        }
+    });
+    console.log('Selected Places:', selectedPlaces);
+    console.log('Markers:', markers);
+
 }
 
 /**

--- a/src/main/resources/static/js/createtrip.js
+++ b/src/main/resources/static/js/createtrip.js
@@ -121,12 +121,10 @@ function handleSelectBtnClick(event, place, placePosition) {
     }
 
     const locationsContainer = selectedDateDiv.querySelector('.dayLocation');
-    const currentLocationCount = locationsContainer.querySelectorAll('.locations').length;
     const MAX_LOCATIONS = 15;
 
-    console.log('currentLocationCount: {}', currentLocationCount);
-    console.log('selectedPlaces: {}', selectedPlaces);
-    if (currentLocationCount + selectedPlaces[dayNum].length > MAX_LOCATIONS) {
+    console.log('selectedPlaces[dayNum]: {}', selectedPlaces[dayNum]);
+    if (selectedPlaces[dayNum].length >= MAX_LOCATIONS) {
         alert(`하루에 추가할 수 있는 장소는 최대 ${MAX_LOCATIONS}개입니다.`);
         return;
     }
@@ -135,7 +133,11 @@ function handleSelectBtnClick(event, place, placePosition) {
     locations.className = 'locations';
 
     locations.innerHTML = `
-            <input type="text" name="placeName" value="${place.place_name}" readonly />
+            <div class="placeNameContainer">
+                <span>${selectedPlaces[dayNum].length + 1}</span>
+                <input type="text" class="placeNameInput" value="${place.place_name}" readonly />
+                <button type="button" onclick="removeElement(this.parentNode)">삭제</button>
+            </div>
             <input type="hidden" name="longitude" value="${place.x}" />
             <input type="hidden" name="latitude" value="${place.y}" />
         `;
@@ -278,10 +280,10 @@ function displayPlaces(places) {
         });
 
         // 항목 당 제거 버튼 클릭 이벤트
-        const removeBtn = itemEl.querySelector('.remove-btn');
-        removeBtn.addEventListener('click', function (event) {
-            handleRemoveBtnClick(event, places[i], placePosition);
-        });
+        // const removeBtn = itemEl.querySelector('.remove-btn');
+        // removeBtn.addEventListener('click', function (event) {
+        //     handleRemoveBtnClick(event, places[i], placePosition);
+        // });
 
         fragment.appendChild(itemEl);
     }
@@ -314,8 +316,10 @@ function getListItem(index, places) {
     itemStr += '  <span class="tel">' + places.phone + '</span>' +
         '</div>';
 
-    itemStr += '<div><button class="select-btn" id="selectBtn">선택</button>' +
-        '<button class="remove-btn" id="removeBtn">제거</button></div>';
+    // itemStr += '<div><button class="select-btn" id="selectBtn">선택</button>' +
+    //     '<button class="remove-btn" id="removeBtn">제거</button></div>';
+
+    itemStr += '<div><button class="select-btn" id="selectBtn">선택</button></div>';
 
     el.innerHTML = itemStr;
     el.className = 'item';

--- a/src/main/resources/static/js/createtrip.js
+++ b/src/main/resources/static/js/createtrip.js
@@ -1,8 +1,8 @@
 // 마커를 담을 배열
-let markers = [];
+// let markers = [];
 
 // 선택된 장소들을 저장할 배열
-let selectedPlaces = [];
+// let selectedPlaces = [];
 
 const mapContainer = document.getElementById('map'), // 지도를 표시할 div
     mapOption = {
@@ -20,7 +20,7 @@ const bounds = new kakao.maps.LatLngBounds();
 const ps = new kakao.maps.services.Places();
 
 // 키워드로 장소를 검색합니다
-searchPlaces();
+// searchPlaces();
 
 /**
  * 키워드 검색을 요청하는 함수입니다
@@ -98,11 +98,19 @@ function handleSelectBtnClick(event, place, placePosition) {
 
     // selectedPlaces 배열의 각 요소 p의 id가 인자로 전달된 place의 id와 같은지 확인
     // .some()은 배열의 각 요소에 대한 테스트 -> true 또는 false 반환
-    const isAlreadySelected = selectedPlaces.some(p => p.id === place.id);
+    // const isAlreadySelected = selectedPlaces.some(p => p.id === place.id);
 
     // 이미 선택된 장소인지 확인
-    if (isAlreadySelected) {
-        alert('이미 선택된 장소입니다.');
+    // if (isAlreadySelected) {
+    //     alert('이미 선택된 장소입니다.');
+    //     return;
+    // }
+
+    // addLocation에서 반환된 dayNum을 가져옴
+    const dayNum = addLocation(selectedDateDiv);
+
+    if (!dayNum) {
+        alert('날짜를 선택해 주세요.');
         return;
     }
 
@@ -112,13 +120,51 @@ function handleSelectBtnClick(event, place, placePosition) {
         return;
     }
 
+    const locationsContainer = selectedDateDiv.querySelector('.dayLocation');
+    const currentLocationCount = locationsContainer.querySelectorAll('.locations').length;
+    const MAX_LOCATIONS = 15;
+
+    console.log('currentLocationCount: {}', currentLocationCount);
+    console.log('selectedPlaces: {}', selectedPlaces);
+    if (currentLocationCount + selectedPlaces[dayNum].length > MAX_LOCATIONS) {
+        alert(`하루에 추가할 수 있는 장소는 최대 ${MAX_LOCATIONS}개입니다.`);
+        return;
+    }
+
+    const locations = document.createElement('div');
+    locations.className = 'locations';
+
+    locations.innerHTML = `
+            <input type="text" name="placeName" value="${place.place_name}" readonly />
+            <input type="hidden" name="longitude" value="${place.x}" />
+            <input type="hidden" name="latitude" value="${place.y}" />
+        `;
+    locationsContainer.appendChild(locations);
+
+    // selectedPlaces.forEach(place => {
+    //     const locations = document.createElement('div');
+    //     locations.className = 'locations';
+    //
+    //     locations.innerHTML = `
+    //     <input type="text" name="placeName" value="${place.place_name}" readonly />
+    //     <input type="hidden" name="longitude" value="${place.x}" />
+    //     <input type="hidden" name="latitude" value="${place.y}" />
+    // `;
+    //     locationsContainer.appendChild(locations);
+    // });
+
+    // selectedPlaces = [];
+    // selectedDateDiv = null;
+    // 선택 완료 버튼 누를 시 검색창 숨기기
+    // $('#menu_wrap').hide();
+
     // 같은 id를 가진 장소가 없고, 15개 초과가 아니라면 선택 장소 목록 배열에 추가
-    selectedPlaces.push(place);
+    selectedPlaces[dayNum].push(place);
 
     // 배열 인덱스로 마커에 번호 부여
-    const index = selectedPlaces.length;
+    const index = selectedPlaces[dayNum].length;
     // 지도에 마커 추가
-    addSelectedMarker(placePosition, index);
+    addSelectedMarker(placePosition, index, dayNum);
     // 마커 번호 재정렬
     reorderMarkers(markers);
 
@@ -283,7 +329,7 @@ function getListItem(index, places) {
  * @param idx - 마커의 인덱스
  * @returns {kakao.maps.Marker} - 생성된 마커 객체
  */
-function addSelectedMarker(position, idx) {
+function addSelectedMarker(position, idx, dayNum) {
     const imageSrc = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png', // 마커 이미지 url, 스프라이트 이미지를 씁니다
         imageSize = new kakao.maps.Size(36, 37),  // 마커 이미지의 크기
         imgOptions = {
@@ -298,7 +344,9 @@ function addSelectedMarker(position, idx) {
         });
 
     marker.setMap(map);
-    markers.push(marker);
+    // markers.push(marker);
+    markers[dayNum].push(marker);
+    console.log('createtrip.js ----- ', markers);
 
     return marker;
 }

--- a/src/main/resources/static/js/createtrip.js
+++ b/src/main/resources/static/js/createtrip.js
@@ -104,12 +104,6 @@ function handleSelectBtnClick(event, place, placePosition) {
         return;
     }
 
-    // 장소는 최대 15개까지만 선택되도록 제한
-    if (selectedPlaces.length >= 15) {
-        alert('최대 15개의 장소만 추가할 수 있습니다.');
-        return;
-    }
-
     const locationsContainer = selectedDateDiv.querySelector('.dayLocation');
     const MAX_LOCATIONS = 15;
 
@@ -135,7 +129,7 @@ function handleSelectBtnClick(event, place, placePosition) {
         `;
     locationsContainer.appendChild(locations);
 
-    // 같은 id를 가진 장소가 없고, 15개 초과가 아니라면 선택 장소 목록 배열에 추가
+    // 15개 초과가 아니라면 선택 장소 목록 배열에 추가
     selectedPlaces[dayNum].push(place);
 
     // 배열 인덱스로 마커에 번호 부여

--- a/src/main/resources/static/js/map.js
+++ b/src/main/resources/static/js/map.js
@@ -119,6 +119,8 @@ function handleSelectBtnClick(event, place, placePosition) {
     const index = selectedPlaces.length;
     // 지도에 마커 추가
     addSelectedMarker(placePosition, index);
+    // 마커 번호 재정렬
+    reorderMarkers(markers);
 
     // 지도 범위 재설정
     setBounds(placePosition);

--- a/src/main/resources/static/js/updatetrip.js
+++ b/src/main/resources/static/js/updatetrip.js
@@ -333,7 +333,7 @@ function addSavedPlacesMarker(latitude, longitude, idx, dayNum) {
         imageSize = new kakao.maps.Size(36, 37),  // 마커 이미지의 크기
         imgOptions = {
             spriteSize: new kakao.maps.Size(36, 691), // 스프라이트 이미지의 크기
-            spriteOrigin: new kakao.maps.Point(0, ((idx - 1) * 46) + 10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
+            spriteOrigin: new kakao.maps.Point(0, ((idx) * 46) + 10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
             offset: new kakao.maps.Point(13, 37) // 마커 좌표에 일치시킬 이미지 내에서의 좌표
         },
         markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imgOptions),
@@ -344,7 +344,6 @@ function addSavedPlacesMarker(latitude, longitude, idx, dayNum) {
 
     marker.setMap(map);
     markers[dayNum].push(marker);
-    // setBounds(marker.position);
     console.log('markres: {}', markers);
 
     return marker;

--- a/src/main/resources/static/js/updatetrip.js
+++ b/src/main/resources/static/js/updatetrip.js
@@ -344,6 +344,7 @@ function addSavedPlacesMarker(latitude, longitude, idx, dayNum) {
 
     marker.setMap(map);
     markers[dayNum].push(marker);
+    setBounds(new kakao.maps.LatLng(latitude, longitude));
     console.log('markres: {}', markers);
 
     return marker;

--- a/src/main/resources/static/js/updatetrip.js
+++ b/src/main/resources/static/js/updatetrip.js
@@ -152,75 +152,79 @@ function handleSelectBtnClick(event, place, placePosition) {
 function handleRemoveBtnClick(event, placeUniqueId, placePositionLa, placePositionMa) {
     event.stopPropagation();
 
-    // uniqueId에서 dayNum과 placeIndex를 추출
-    const [dayNum, placeIndex] = placeUniqueId.split('-').map(Number);
+    // 클릭된 버튼
+    const button = event.target;
+
+    // 버튼의 부모 요소
+    const parentElement = button.parentElement;
+
+    // 부모 요소 내에서 형제 요소 중 span 태그 찾기
+    const spanElement = parentElement.querySelector('span');
+
+    // span 태그의 id에서 dayNum과 placeIndex 추출
+    const [dayNum, placeIndex] = spanElement.id.split('-').map(Number);
+    // const [, placeIndex] = spanElement.id.split('-').map(Number);
 
     // selectedPlaces에서 해당 날짜와 인덱스에 있는 장소를 삭제
     if (selectedPlaces[dayNum]) {
-        // 인덱스가 유효한지 확인하고 해당 장소를 삭제
-        if (placeIndex <= selectedPlaces[dayNum].length && placeIndex > 0) {
-            selectedPlaces[dayNum].splice(placeIndex - 1, 1); // placeIndex는 0부터 시작하므로 -1
+        selectedPlaces[dayNum].splice(placeIndex - 1, 1); // 인덱스는 0부터 시작하므로 -1
 
-            // placesContainer에서 해당 장소를 포함하는 element를 찾아서 삭제
-            const locationElements = document.querySelectorAll('.placeNameContainer');
-            locationElements.forEach(element => {
-                if (element.querySelector('span').id === placeUniqueId) {
-                    element.parentNode.remove(); // 해당 요소 삭제
-                }
-            });
+        // placesContainer에서 해당 장소를 포함하는 element를 찾아서 삭제
+        parentElement.parentElement.remove();
 
-            // 남아있는 요소들의 인덱스를 갱신
-            updatePlaceIndexes(dayNum);
+        // markers 배열에서 해당 장소 위치에 해당하는 marker 요소 제거
+        const tolerance = 0.00000001; // 허용 오차 범위 설정
 
-            // markers 배열에서 해당 장소 위치에 해당하는 marker 요소 제거
-            const tolerance = 0.00000001; // 허용 오차 범위 설정
+        // findIndex는 배열에 각 요소에 대해 조건을 만족하는 첫 번째 요소의 인덱스 반환
+        const markerIndex = markers[dayNum].findIndex(marker => {
+            const markerPos = marker.getPosition();
+            // 오차 범위 이내면 같은 장소로 취급
+            return Math.abs(markerPos.La - placePositionLa) < tolerance &&
+                Math.abs(markerPos.Ma - placePositionMa) < tolerance;
+        });
 
-            // findIndex는 배열에 각 요소에 대해 조건을 만족하는 첫 번째 요소의 인덱스 반환
-            const markerIndex = markers[dayNum].findIndex(marker => {
-                const markerPos = marker.getPosition();
-                // 오차 범위 이내면 같은 장소로 취급
-                return Math.abs(markerPos.La - placePositionLa) < tolerance &&
-                    Math.abs(markerPos.Ma - placePositionMa) < tolerance;
-            });
-
-            if (markerIndex !== -1) {   // 해당 장소 위치의 마커가 존재한다면
-                markers[dayNum][markerIndex].setMap(null);  // 지도에서 마커 제거
-                markers[dayNum].splice(markerIndex, 1); // 배열에서 마커 제거. 인덱스부터 1개의 요소 삭제
-                reorderMarkers(markers[dayNum]);    // 마커 번호 재정렬
-            }
-
-        } else {
-            console.error(`장소 인덱스가 유효하지 않습니다. 인덱스: ${placeIndex}, 길이: ${selectedPlaces[dayNum].length}`);
+        if (markerIndex !== -1) {   // 해당 장소 위치의 마커가 존재한다면
+            markers[dayNum][markerIndex].setMap(null);  // 지도에서 마커 제거
+            markers[dayNum].splice(markerIndex, 1); // 배열에서 마커 제거. 인덱스부터 1개의 요소 삭제
         }
+
+        console.log('Selected Places:', selectedPlaces);
+        console.log('Markers:', markers);
+
+        // 장소와 마커가 삭제된 후, 나머지 요소들의 인덱스와 ID를 업데이트
+        updatePlaceIndexes(dayNum);
+        reorderMarkers(markers[dayNum]);    // 마커 번호 재정렬
+
+        // console.log('삭제 후 selectedPlaces[dayNum].length: ', selectedPlaces[dayNum].length);
+
+        // } else {
+        //     console.error('장소 인덱스가 유효하지 않습니다.');
+        // }
     } else {
         console.error('dayNum이 존재하지 않습니다.');
     }
 }
 
+/**
+ * 삭제 후 나머지 장소의 인덱스와 ID를 업데이트하는 함수
+ * @param dayNum - 선택된 날짜의 번호
+ */
 function updatePlaceIndexes(dayNum) {
-    // 날짜별 마커의 수를 가져옴
-    const numberOfPlaces = markers[dayNum] ? markers[dayNum].length : 0;
+    // 해당 날짜의 모든 placeNameContainer 요소를 선택
+    const locationElements = document.querySelectorAll(`.trip-date:nth-child(${dayNum}) .trip-location .placeNameContainer`);
 
-    // 해당 날짜의 모든 장소 요소를 선택
-    const locationElements = document.querySelectorAll('.trip-location');
-
-    // 날짜별 인덱스 시작 값
-    let index = 1;
-
-    locationElements.forEach(element => {
-        const span = element.querySelector('.placeNameContainer span');
-        if (span) {
-            // 새로운 인덱스 값을 span에 설정
-            span.innerText = index;
-
-            // span의 id를 새로운 인덱스에 맞게 업데이트
-            const idParts = span.id.split('-');
-            const newId = `${dayNum}-${index}`;
-            span.id = newId;
-
-            index++;
+    // 각 placeNameContainer의 span 태그의 id와 내용을 업데이트
+    locationElements.forEach((placeNameContainer, index) => {
+        const spanElement = placeNameContainer.querySelector('span');
+        if (spanElement) {
+            const newId = `${dayNum}-${index + 1}`;
+            spanElement.id = newId; // 새로운 id 설정
+            spanElement.textContent = index + 1; // 새로운 번호 설정
         }
     });
+    console.log('Selected Places:', selectedPlaces);
+    console.log('Markers:', markers);
+
 }
 
 // 전체 날짜의 장소 인덱스를 재정렬하는 함수

--- a/src/main/resources/static/js/updatetrip.js
+++ b/src/main/resources/static/js/updatetrip.js
@@ -1,0 +1,395 @@
+// 마커를 담을 배열
+// let markers = [];
+
+// 선택된 장소들을 저장할 배열
+// let selectedPlaces = [];
+
+const mapContainer = document.getElementById('map'), // 지도를 표시할 div
+    mapOption = {
+        center: new kakao.maps.LatLng(37.566826, 126.9786567), // 지도의 중심좌표
+        level: 3 // 지도의 확대 레벨
+    };
+
+// 지도를 생성합니다
+const map = new kakao.maps.Map(mapContainer, mapOption);
+
+// 지도를 재설정할 범위정보를 가지고 있을 LatLngBounds 객체를 생성
+const bounds = new kakao.maps.LatLngBounds();
+
+// 장소 검색 객체를 생성합니다
+const ps = new kakao.maps.services.Places();
+
+// 키워드로 장소를 검색합니다
+// searchPlaces();
+
+/**
+ * 키워드 검색을 요청하는 함수입니다
+ * @returns {boolean} - 키워드가 유효하지 않으면 false
+ */
+function searchPlaces() {
+    const keyword = document.getElementById('keyword').value;
+
+    if (!keyword.replace(/^\s+|\s+$/g, '')) {   // 키워드가 공백만 있는 경우
+        alert('키워드를 입력해주세요!');
+        return false;
+    }
+
+    // 장소검색 객체를 통해 키워드로 장소검색을 요청합니다
+    ps.keywordSearch(keyword, placesSearchCB);
+}
+
+/**
+ * 장소검색이 완료됐을 때 호출되는 콜백함수입니다
+ * @param data - 검색된 장소 데이터 배열
+ * @param status - 검색 결과 응답 상태 코드
+ * @param pagination - 페이지네이션 객체
+ */
+function placesSearchCB(data, status, pagination) {
+    if (status === kakao.maps.services.Status.OK) {
+        // 정상적으로 검색이 완료됐으면 검색 목록과 마커를 표출합니다
+        displayPlaces(data);
+
+        // 페이지 번호를 표출합니다
+        displayPagination(pagination);
+    } else if (status === kakao.maps.services.Status.ZERO_RESULT) {
+        alert('검색 결과가 존재하지 않습니다.');
+        return;
+    } else if (status === kakao.maps.services.Status.ERROR) {
+
+        alert('검색 결과 중 오류가 발생했습니다.');
+        return;
+    }
+}
+
+/**
+ * 장소 데이터를 백단으로 전송하는 함수입니다
+ * @param places - 선택된 장소 데이터 배열
+ */
+function sendPlaceData(places) {
+    // 백단에서 필요한 데이터만 포함된 배열 생성
+    const filteredPlaces = selectedPlaces.map(place => ({
+        name: place.place_name,
+        longitude: place.x,
+        latitude: place.y
+    }));
+
+    $.ajax({
+        url: '/api/save-location',
+        method: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(filteredPlaces),
+        success: function (data) {
+            console.log('success:', data);
+        },
+        error: function (error) {
+            console.error('error:', error);
+        }
+    });
+}
+
+/**
+ * 선택 버튼 클릭 이벤트 핸들러
+ * @param event - 이벤트 객체
+ * @param place - 선택된 장소 데이터
+ * @param placePosition - 장소의 좌표 객체
+ */
+function handleSelectBtnClick(event, place, placePosition) {
+    event.stopPropagation();    // 이벤트 버블링 방지
+
+    // selectedPlaces 배열의 각 요소 p의 id가 인자로 전달된 place의 id와 같은지 확인
+    // .some()은 배열의 각 요소에 대한 테스트 -> true 또는 false 반환
+    const isAlreadySelected = selectedPlaces.some(p => p.id === place.id);
+
+    // 이미 선택된 장소인지 확인
+    if (isAlreadySelected) {
+        alert('이미 선택된 장소입니다.');
+        return;
+    }
+
+    // 장소는 최대 15개까지만 선택되도록 제한
+    if (selectedPlaces.length >= 15) {
+        alert('최대 15개의 장소만 추가할 수 있습니다.');
+        return;
+    }
+
+    // 같은 id를 가진 장소가 없고, 15개 초과가 아니라면 선택 장소 목록 배열에 추가
+    selectedPlaces.push(place);
+
+    // 배열 인덱스로 마커에 번호 부여
+    const index = selectedPlaces.length;
+    // 지도에 마커 추가
+    addSelectedMarker(placePosition, index);
+    // 마커 번호 재정렬
+    reorderMarkers(markers);
+
+    // 지도 범위 재설정
+    setBounds(placePosition);
+}
+
+/**
+ * 제거 버튼 클릭 이벤트 핸들러
+ * @param event - 이벤트 객체
+ * @param place - 선택된 장소 데이터
+ * @param placePosition - 장소의 좌표 객체
+ */
+function handleRemoveBtnClick(event, place, placePosition) {
+    event.stopPropagation();
+
+    // 배열의 각 요소 p의 id가 인자로 전달된 place의 id와 다른 요소만 filter해서 selectedPlaces에 남김
+    // (넘어온 place를 배열에서 삭제)
+    selectedPlaces = selectedPlaces.filter(p => p.id !== place.id);
+
+    // findIndex는 배열에 각 요소에 대해 조건을 만족하는 첫 번째 요소의 인덱스 반환
+    // markers 배열에서 해당 장소 위치에 해당하는 marker 요소 제거
+    const tolerance = 0.00000001; // 허용 오차 범위 설정
+
+    const markerIndex = markers.findIndex(marker => {
+        const markerPos = marker.getPosition();
+        // 오차 범위 내면 같은 장소로 취급
+        return Math.abs(markerPos.La - placePosition.La) < tolerance &&
+            Math.abs(markerPos.Ma - placePosition.Ma) < tolerance;
+    });
+
+    if (markerIndex !== -1) {   // 해당 장소 위치의 마커가 존재한다면
+        markers[markerIndex].setMap(null);  // 지도에서 마커 제거
+        markers.splice(markerIndex, 1); // 배열에서 마커 제거. 인덱스부터 1개의 요소 삭제
+        reorderMarkers(markers);    // 마커 번호 재정렬
+    }
+
+    // 지도 범위 재설정
+    setBounds(placePosition);
+}
+
+/**
+ * 선택 완료 버튼 클릭 이벤트 핸들러
+ */
+// function handleSelectCompleteBtnClick() {
+//     if (selectedPlaces.length === 0) {
+//         alert('선택된 장소가 없습니다. 장소를 추가해 주세요.');
+//         return;
+//     }
+//     sendPlaceData(selectedPlaces);
+//
+//     // 선택된 장소를 createtrip.html에 전달하는 로직을 추가
+//     window.selectedPlaces = [...selectedPlaces];
+//
+//     // 선택 완료 버튼 누를 시 검색창 숨기기
+//     $('#menu_wrap').hide();
+// }
+
+// function handleSelectCompleteBtnClick() {
+//     if (selectedPlaces.length === 0) {
+//         alert('선택된 장소가 없습니다. 장소를 추가해 주세요.');
+//         return;
+//     }
+//
+//     if (!selectedDateDiv) {
+//         alert('장소를 추가할 날짜를 선택해 주세요.');
+//         return;
+//     }
+//
+//     const locationsContainer = selectedDateDiv.querySelector('.dayLocation');
+//     selectedPlaces.forEach(place => {
+//         const locations = document.createElement('div');
+//         locations.className = 'locations';
+//
+//         locations.innerHTML = `
+//             <input type="text" name="placeName" value="${place.place_name}" readonly />
+//             <input type="hidden" name="longitude" value="${place.x}" />
+//             <input type="hidden" name="latitude" value="${place.y}" />
+//         `;
+//         locationsContainer.appendChild(locations);
+//     });
+//
+//     selectedPlaces = [];
+//     selectedDateDiv = null;
+//     // 선택 완료 버튼 누를 시 검색창 숨기기
+//     $('#menu_wrap').hide();
+// }
+
+/**
+ * 검색 결과 목록과 마커를 표출하는 함수입니다
+ * @param places - 검색된 장소 데이터 배열
+ */
+function displayPlaces(places) {
+    const listEl = document.getElementById('placesList'),
+        menuEl = document.getElementById('menu_wrap'),
+        fragment = document.createDocumentFragment(),
+        listStr = '';
+
+    // 검색 결과 목록에 추가된 항목들을 제거합니다
+    removeAllChildNods(listEl);
+
+    for (let i = 0; i < places.length; i++) {
+        // 마커를 생성하고 지도에 표시합니다
+        const itemEl = getListItem(i, places[i]); // 검색 결과 항목 Element를 생성합니다
+        const placePosition = new kakao.maps.LatLng(places[i].y, places[i].x);  // 지도를 재설정할 범위정보를 가지고 있을 LatLngBounds 객체를 생성합니다
+
+        // 항목 당 선택 버튼 클릭 이벤트
+        const selectBtn = itemEl.querySelector('.select-btn');
+        selectBtn.addEventListener('click', function (event) {
+            handleSelectBtnClick(event, places[i], placePosition);
+        });
+
+        // 항목 당 제거 버튼 클릭 이벤트
+        const removeBtn = itemEl.querySelector('.remove-btn');
+        removeBtn.addEventListener('click', function (event) {
+            handleRemoveBtnClick(event, places[i], placePosition);
+        });
+
+        fragment.appendChild(itemEl);
+    }
+
+    // 검색결과 항목들을 검색결과 목록 Element에 추가합니다
+    listEl.appendChild(fragment);
+    menuEl.scrollTop = 0;
+}
+
+/**
+ * 검색결과 항목을 Element로 반환하는 함수입니다
+ * @param index - 검색 결과 항목의 인덱스
+ * @param places - 검색 결과 항목의 데이터
+ * @returns {HTMLLIElement} - 검색 결과 항목 Element
+ */
+function getListItem(index, places) {
+
+    const el = document.createElement('li');
+    // let itemStr = '<span class="markerbg marker_' + (index+1) + '"></span>' +
+    let itemStr = '<div class="info">' +
+        '   <h5>' + places.place_name + '</h5>';
+
+    if (places.road_address_name) {
+        itemStr += '    <span>' + places.road_address_name + '</span>' +
+            '   <span class="jibun gray">' + places.address_name + '</span>';
+    } else {
+        itemStr += '    <span>' + places.address_name + '</span>';
+    }
+
+    itemStr += '  <span class="tel">' + places.phone + '</span>' +
+        '</div>';
+
+    itemStr += '<div><button class="select-btn" id="selectBtn">선택</button>' +
+        '<button class="remove-btn" id="removeBtn">제거</button></div>';
+
+    el.innerHTML = itemStr;
+    el.className = 'item';
+
+    return el;
+}
+
+/**
+ * 선택된 장소의 마커를 생성하고 지도 위에 마커를 표시하는 함수입니다.
+ * @param position - 마커의 좌표 객체
+ * @param idx - 마커의 인덱스
+ * @returns {kakao.maps.Marker} - 생성된 마커 객체
+ */
+function addSelectedMarker(position, idx) {
+    const imageSrc = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png', // 마커 이미지 url, 스프라이트 이미지를 씁니다
+        imageSize = new kakao.maps.Size(36, 37),  // 마커 이미지의 크기
+        imgOptions = {
+            spriteSize: new kakao.maps.Size(36, 691), // 스프라이트 이미지의 크기
+            spriteOrigin: new kakao.maps.Point(0, ((idx - 1) * 46) + 10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
+            offset: new kakao.maps.Point(13, 37) // 마커 좌표에 일치시킬 이미지 내에서의 좌표
+        },
+        markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imgOptions),
+        marker = new kakao.maps.Marker({
+            position: position, // 마커의 위치
+            image: markerImage
+        });
+
+    marker.setMap(map);
+    markers.push(marker);
+    console.log('createtrip.js ----- ', markers);
+
+    return marker;
+}
+
+/**
+ * 제거 버튼 클릭 이벤트 발생 시 기존에 있던 마커 번호(마커 이미지)를 재정렬하는 함수
+ * @param markers - 선택된 장소들의 마커 배열
+ */
+function reorderMarkers(markers) {
+    for (let i = 0; i < markers.length; i++) {
+        const marker = markers[i];
+
+        const imageSrc = 'https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png', // 마커 이미지 url, 스프라이트 이미지를 씁니다
+            imageSize = new kakao.maps.Size(36, 37),  // 마커 이미지의 크기
+            imgOptions = {
+                spriteSize: new kakao.maps.Size(36, 691), // 스프라이트 이미지의 크기
+                spriteOrigin: new kakao.maps.Point(0, (i * 46) + 10), // 스프라이트 이미지 중 사용할 영역의 좌상단 좌표
+                offset: new kakao.maps.Point(13, 37) // 마커 좌표에 일치시킬 이미지 내에서의 좌표
+            },
+            markerImage = new kakao.maps.MarkerImage(imageSrc, imageSize, imgOptions);
+
+        marker.setImage(markerImage);
+    }
+}
+
+/**
+ * 지도 위에 표시되고 있는 마커를 모두 제거합니다
+ */
+function removeMarker() {
+    for (let i = 0; i < markers.length; i++) {
+        markers[i].setMap(null);
+    }
+    markers = [];
+}
+
+/**
+ * 지도 범위 재설정 함수입니다
+ * @param placePosition - 마커의 좌표 객체
+ */
+function setBounds(placePosition) {
+    // LatLngBounds 객체에 좌표를 추가
+    bounds.extend(placePosition);
+    // LatLngBounds 객체에 추가된 좌표들을 기준으로 지도의 범위를 재설정합니다
+    // 이때 지도의 중심좌표와 레벨이 변경될 수 있습니다
+    map.setBounds(bounds);
+}
+
+/**
+ * 검색결과 목록 하단에 페이지번호를 표시는 함수입니다
+ * @param pagination - 페이지네이션 객체
+ */
+function displayPagination(pagination) {
+    const paginationEl = document.getElementById('pagination');
+    const fragment = document.createDocumentFragment();
+    let i;
+
+    // 기존에 추가된 페이지번호를 삭제합니다
+    while (paginationEl.hasChildNodes()) {
+        paginationEl.removeChild(paginationEl.lastChild);
+    }
+
+    for (i = 1; i <= pagination.last; i++) {
+        const el = document.createElement('a');
+        el.href = "#";
+        el.innerHTML = i;
+
+        if (i === pagination.current) {
+            el.className = 'on';
+        } else {
+            el.onclick = (function (i) {
+                return function () {
+                    pagination.gotoPage(i);
+                }
+            })(i);
+        }
+
+        fragment.appendChild(el);
+    }
+    paginationEl.appendChild(fragment);
+}
+
+/**
+ * 검색결과 목록의 자식 Element를 제거하는 함수입니다
+ * @param el - 검색 결과 목록 요소
+ */
+function removeAllChildNods(el) {
+    while (el.hasChildNodes()) {
+        el.removeChild(el.lastChild);
+    }
+}
+
+// 선택 완료 버튼에 클릭 이벤트 리스너 추가
+// document.querySelector('button[type="button"]').addEventListener('click', handleSelectCompleteBtnClick);

--- a/src/main/resources/templates/trip/createtrip.html
+++ b/src/main/resources/templates/trip/createtrip.html
@@ -12,6 +12,7 @@
 <div class="container">
     <!-- 여행 일정 생성 영역 -->
     <div class="form_wrap">
+        <a href="" class="backLink">↩️ 목록으로 돌아가기(경로 추가 필요)</a>
         <form id="tripForm">
             <h1>여행 일정 생성</h1>
             <label for="tripName">여행 이름</label>
@@ -405,10 +406,14 @@
             locationsContainer.appendChild(locations);
         });
 
+        console.log('초기화 전: {}', selectedPlaces);
+
         selectedPlaces = [];
         selectedDateDiv = null;
         // 선택 완료 버튼 누를 시 검색창 숨기기
         $('#menu_wrap').hide();
+
+        console.log('초기화 후: {}', selectedPlaces);
     }
 
     // 선택 완료 버튼 클릭 이벤트

--- a/src/main/resources/templates/trip/createtrip.html
+++ b/src/main/resources/templates/trip/createtrip.html
@@ -62,7 +62,7 @@
                 <div>
                     <!-- 검색 폼 제출 시 searchPlaces() 호출 -->
                     <form onsubmit="searchPlaces(); return false;">
-                        <input type="text" value="부산 맛집" id="keyword" size="15">
+                        <input type="text" placeholder="장소명을 입력해주세요." id="keyword" size="15">
                         <button type="submit" id="searchBtn">검색하기</button>
                     </form>
                     <button type="button" id="completeBtn">선택 완료</button>
@@ -79,154 +79,21 @@
 
 <script>
     const regions = {
-        "특별시/광역시": [
-            "서울특별시",
-            "부산광역시",
-            "대구광역시",
-            "인천광역시",
-            "광주광역시",
-            "대전광역시",
-            "울산광역시",
-            "세종특별자치시"
-        ],
-        "강원도": [
-            "춘천시",
-            "원주시",
-            "강릉시",
-            "동해시",
-            "태백시",
-            "속초시",
-            "삼척시",
-            "홍천군",
-            "횡성군",
-            "평창군",
-            "정선군",
-            "영월군"
-        ],
-        "경기도": [
-            "수원시",
-            "고양시",
-            "용인시",
-            "성남시",
-            "부천시",
-            "남양주시",
-            "안산시",
-            "안양시",
-            "평택시",
-            "의정부시",
-            "군포시",
-            "오산시",
-            "시흥시",
-            "하남시",
-            "의왕시",
-            "양주시",
-            "파주시",
-            "광명시",
-            "구리시",
-            "여주시"
-        ],
-        "경상남도": [
-            "창원시",
-            "김해시",
-            "진주시",
-            "양산시",
-            "거제시",
-            "통영시",
-            "사천시",
-            "밀양시",
-            "함안군",
-            "거창군",
-            "창녕군",
-            "산청군",
-            "의령군",
-            "고성군",
-            "하동군",
-            "합천군"
-        ],
-        "경상북도": [
-            "포항시",
-            "경주시",
-            "구미시",
-            "김천시",
-            "안동시",
-            "영주시",
-            "상주시",
-            "문경시",
-            "경산시",
-            "영천시",
-            "청송군",
-            "영양군",
-            "봉화군",
-            "울릉군",
-            "예천군",
-            "성주군",
-            "군위군",
-            "의성군"
-        ],
-        "충청남도": [
-            "천안시",
-            "아산시",
-            "서산시",
-            "논산시",
-            "보령시",
-            "계룡시",
-            "당진시",
-            "금산군",
-            "부여군",
-            "서천군",
-            "홍성군",
-            "예산군",
-            "청양군",
-            "태안군"
-        ],
-        "충청북도": [
-            "청주시",
-            "충주시",
-            "제천시",
-            "보은군",
-            "옥천군",
-            "영동군"
-        ],
-        "전라남도": [
-            "여수시",
-            "순천시",
-            "목포시",
-            "나주시",
-            "광양시",
-            "담양군",
-            "곡성군",
-            "구례군",
-            "고흥군",
-            "보성군",
-            "장흥군",
-            "강진군",
-            "해남군",
-            "완도군",
-            "진도군",
-            "신안군",
-            "무안군",
-            "영암군"
-        ],
-        "전라북도": [
-            "전주시",
-            "군산시",
-            "익산시",
-            "남원시",
-            "정읍시",
-            "김제시",
-            "완주군",
-            "진안군",
-            "무주군",
-            "장수군",
-            "고창군",
-            "임실군",
-            "순창군"
-        ],
-        "제주특별자치도": [
-            "제주시",
-            "서귀포시"
-        ]
+        "특별시/광역시": ["서울특별시", "부산광역시", "대구광역시", "인천광역시", "광주광역시", "대전광역시", "울산광역시", "세종특별자치시"],
+        "강원도": ["춘천시", "원주시", "강릉시", "동해시", "태백시", "속초시", "삼척시", "홍천군", "횡성군", "평창군", "정선군", "영월군"],
+        "경기도": ["수원시", "고양시", "용인시", "성남시", "부천시", "남양주시", "안산시", "안양시", "평택시", "의정부시", "군포시", "오산시", "시흥시", "하남시", "의왕시", "양주시", "파주시", "광명시", "구리시", "여주시"],
+        "경상남도": ["창원시", "김해시", "진주시", "양산시", "거제시", "통영시", "사천시", "밀양시", "함안군", "거창군", "창녕군", "산청군", "의령군", "고성군", "하동군", "합천군"],
+        "경상북도": ["포항시", "경주시", "구미시", "김천시", "안동시", "영주시", "상주시", "문경시", "경산시", "영천시", "청송군", "영양군", "봉화군", "울릉군", "예천군", "성주군", "군위군", "의성군"],
+        "충청남도": ["천안시", "아산시", "서산시", "논산시", "보령시", "계룡시", "당진시", "금산군", "부여군", "서천군", "홍성군", "예산군", "청양군", "태안군"],
+        "충청북도": ["청주시", "충주시", "제천시", "보은군", "옥천군", "영동군"],
+        "전라남도": ["여수시", "순천시", "목포시", "나주시", "광양시", "담양군", "곡성군", "구례군", "고흥군", "보성군", "장흥군", "강진군", "해남군", "완도군", "진도군", "신안군", "무안군", "영암군"],
+        "전라북도": ["전주시", "군산시", "익산시", "남원시", "정읍시", "김제시", "완주군", "진안군", "무주군", "장수군", "고창군", "임실군", "순창군"],
+        "제주특별자치도": ["제주시", "서귀포시"]
     };
+
+    let markers = {};
+    let selectedDateDiv = null;
+    let selectedPlaces = {};
 
     function updateCities() {
         const regionSelect = document.getElementById('regionSelect');
@@ -362,72 +229,48 @@
     }
 
     function addLocation(button) {
+        // 장소 추가 버튼을 누를 시 menu_wrap이 보이도록 설정
+        document.getElementById('menu_wrap').style.display = 'block';
 
         selectedDateDiv = button.closest('.tripDate');
 
-        // const locationHtml = `
-        //     <div class="locations">
-        //         <label for="placeName">장소 이름:</label>
-        //         <input type="text" name="placeName" required><br>
-        //         <label for="latitude">위도:</label>
-        //         <input type="number" step="0.000001" name="latitude"><br>
-        //         <label for="longitude">경도:</label>
-        //         <input type="number" step="0.000001" name="longitude"><br>
-        //     </div>
-        // `;
-        // button.insertAdjacentHTML('beforebegin', locationHtml);
-        // console.log('Location added.');
+        // 여행 몇째 날인지 추출 (ex. 1, 2, ..)
+        if (selectedDateDiv) {
+            // Day 정보를 포함하는 span 요소 선택
+            const dayCountSpan = selectedDateDiv.querySelector('.dayCountLabel');
 
-        // 장소 추가 버튼을 누를 시 menu_wrap이 보이도록 설정
-        document.getElementById('menu_wrap').style.display = 'block';
-    }
+            if (dayCountSpan) {
+                // "Day 1"과 같은 텍스트를 가져옴
+                const dayText = dayCountSpan.textContent.trim();
 
-    function handleSelectCompleteBtnClick() {
-        if (selectedPlaces.length === 0) {
-            alert('선택된 장소가 없습니다. 장소를 추가해 주세요.');
-            return;
+                // "Day 1"에서 숫자 부분만 추출
+                const dayNum = dayText.replace('Day ', '');
+
+                // selectedPlaces 객체에서 dayNum에 해당하는 배열이 없으면 초기화
+                if (!selectedPlaces[dayNum]) {
+                    selectedPlaces[dayNum] = [];
+                }
+
+                if (!markers[dayNum]) {
+                    markers[dayNum] = [];
+                }
+
+                return dayNum; // 예: "1"
+            } else {
+                console.error('Day count span not found in selectedDateDiv.');
+            }
+        } else {
+            console.error('selectedDateDiv is not set.');
         }
-
-        if (!selectedDateDiv) {
-            alert('장소를 추가할 날짜를 선택해 주세요.');
-            return;
-        }
-
-        const locationsContainer = selectedDateDiv.querySelector('.dayLocation');
-        const currentLocationCount = locationsContainer.querySelectorAll('.locations').length;
-        const MAX_LOCATIONS = 15;
-
-        console.log('currentLocationCount: {}', currentLocationCount);
-        console.log('selectedPlaces: {}', selectedPlaces);
-        if (currentLocationCount + selectedPlaces.length > MAX_LOCATIONS) {
-            alert(`하루에 추가할 수 있는 장소는 최대 ${MAX_LOCATIONS}개입니다.`);
-            return;
-        }
-
-        selectedPlaces.forEach(place => {
-            const locations = document.createElement('div');
-            locations.className = 'locations';
-
-            locations.innerHTML = `
-            <input type="text" name="placeName" value="${place.place_name}" readonly />
-            <input type="hidden" name="longitude" value="${place.x}" />
-            <input type="hidden" name="latitude" value="${place.y}" />
-        `;
-            locationsContainer.appendChild(locations);
-        });
-
-        selectedPlaces = [];
-        selectedDateDiv = null;
-        // 선택 완료 버튼 누를 시 검색창 숨기기
-        $('#menu_wrap').hide();
+        return null;
     }
 
     // 선택 완료 버튼 클릭 이벤트
-    document.getElementById('completeBtn').addEventListener('click', handleSelectCompleteBtnClick);
+    // document.getElementById('completeBtn').addEventListener('click', handleSelectCompleteBtnClick);
 </script>
 <script type="text/javascript"
         src="//dapi.kakao.com/v2/maps/sdk.js?appkey=c60fdc23b01e5e1886e831583b4cefb0&libraries=services"></script>
-<script src="/js/map.js"></script>
+<script src="/js/createtrip.js"></script>
 </body>
 </html>
 

--- a/src/main/resources/templates/trip/createtrip.html
+++ b/src/main/resources/templates/trip/createtrip.html
@@ -65,7 +65,7 @@
                         <input type="text" placeholder="장소명을 입력해주세요." id="keyword" size="15">
                         <button type="submit" id="searchBtn">검색하기</button>
                     </form>
-                    <button type="button" id="completeBtn">선택 완료</button>
+                    <button type="button" id="closeBtn">창 닫기</button>
                 </div>
             </div>
             <hr>
@@ -265,8 +265,10 @@
         return null;
     }
 
-    // 선택 완료 버튼 클릭 이벤트
-    // document.getElementById('completeBtn').addEventListener('click', handleSelectCompleteBtnClick);
+    // 창 닫기 버튼 클릭 시 #menu_wrap 숨기기
+    document.getElementById('closeBtn').addEventListener('click', function() {
+        $('#menu_wrap').hide();
+    });
 </script>
 <script type="text/javascript"
         src="//dapi.kakao.com/v2/maps/sdk.js?appkey=c60fdc23b01e5e1886e831583b4cefb0&libraries=services"></script>

--- a/src/main/resources/templates/trip/createtrip.html
+++ b/src/main/resources/templates/trip/createtrip.html
@@ -394,6 +394,16 @@
         }
 
         const locationsContainer = selectedDateDiv.querySelector('.dayLocation');
+        const currentLocationCount = locationsContainer.querySelectorAll('.locations').length;
+        const MAX_LOCATIONS = 15;
+
+        console.log('currentLocationCount: {}', currentLocationCount);
+        console.log('selectedPlaces: {}', selectedPlaces);
+        if (currentLocationCount + selectedPlaces.length > MAX_LOCATIONS) {
+            alert(`하루에 추가할 수 있는 장소는 최대 ${MAX_LOCATIONS}개입니다.`);
+            return;
+        }
+
         selectedPlaces.forEach(place => {
             const locations = document.createElement('div');
             locations.className = 'locations';
@@ -406,14 +416,10 @@
             locationsContainer.appendChild(locations);
         });
 
-        console.log('초기화 전: {}', selectedPlaces);
-
         selectedPlaces = [];
         selectedDateDiv = null;
         // 선택 완료 버튼 누를 시 검색창 숨기기
         $('#menu_wrap').hide();
-
-        console.log('초기화 후: {}', selectedPlaces);
     }
 
     // 선택 완료 버튼 클릭 이벤트

--- a/src/main/resources/templates/trip/updatetrip.html
+++ b/src/main/resources/templates/trip/updatetrip.html
@@ -109,6 +109,11 @@
         });
     });
 
+    /**
+     * fetchTripData에서 호출되어 각 여행 날짜 동적으로 생성
+     * 여행 장소 상세는 createTripLocationHtml에서 생성
+     * @param tripDateData
+     */
     function addTripDate(tripDateData = {}) {
         const tripDateId = tripDatesCounter++;
         const tripDateElement = document.createElement('div');
@@ -122,7 +127,7 @@
           <input type="hidden" class="tripDateInput" value="${tripDateData.tripDate || ''}" disabled>
         </div>
         <div class="trip-locations">
-          ${tripDateData.tripLocations ? tripDateData.tripLocations.map(loc => createTripLocationHtml(loc)).join('') : ''}
+          ${tripDateData.tripLocations ? tripDateData.tripLocations.map((loc, index) => createTripLocationHtml(loc, tripDateId + 1, index + 1)).join('') : ''}
         </div>
         <button type="button" onclick="addTripLocation(this)">장소 추가</button>
       `;
@@ -137,17 +142,15 @@
                 latitude: loc.latitude,
                 longitude: loc.longitude
             }));
-        } else {    // tripDateData의 tripLocations이 존재하지 않는다면 해당 날짜에는 장소가 없으니 빈 배열로 초기화
-            selectedPlaces[dayNum] = [];
-        }
 
-        // 받아온 데이터를 기반으로 markers 객체 초기화
-        if (tripDateData.tripLocations) {
-            markers[dayNum] = tripDateData.tripLocations.map(loc => ({  // 배열을 순회하면서 객체에 할당
-                latitude: loc.latitude,
-                longitude: loc.longitude
-            }));
-        } else { // tripDateData의 tripLocations이 존재하지 않는다면 해당 날짜에는 마커가 없으니 빈 배열로 초기화
+            markers[dayNum] = [];
+            tripDateData.tripLocations.forEach((loc) => {
+                // 카카오 API 기본 markers와 같게 구현하기 위해 addSavedPlacesMarker를 통해 카카오 API marker 객체로 생성
+                addSavedPlacesMarker(loc.latitude, loc.longitude, markers[dayNum].length, dayNum);
+            });
+
+        } else {    // tripDateData의 tripLocations이 존재하지 않는다면 해당 날짜에는 장소와 마커가 없으니 빈 배열로 초기화
+            selectedPlaces[dayNum] = [];
             markers[dayNum] = [];
         }
 
@@ -159,7 +162,37 @@
         // 장소 추가 버튼을 누를 시 menu_wrap이 보이도록 설정
         document.getElementById('menu_wrap').style.display = 'block';
 
-        selectedDateDiv = button.closest('.tripDate');
+        selectedDateDiv = button.closest('.trip-date');
+
+        // 여행 몇째 날인지 추출 (ex. 1, 2, ..)
+        if (selectedDateDiv) {
+            // Day 정보를 포함하는 span 요소 선택
+            const dayCountSpan = selectedDateDiv.querySelector('.dayCountLabel');
+
+            if (dayCountSpan) {
+                // "Day 1"과 같은 텍스트를 가져옴
+                const dayText = dayCountSpan.textContent.trim();
+
+                // "Day 1"에서 숫자 부분만 추출
+                const dayNum = dayText.replace('Day ', '');
+
+                // selectedPlaces 객체에서 dayNum에 해당하는 배열이 없으면 초기화
+                if (!selectedPlaces[dayNum]) {
+                    selectedPlaces[dayNum] = [];
+                }
+
+                if (!markers[dayNum]) {
+                    markers[dayNum] = [];
+                }
+
+                return dayNum; // 예: "1"
+            } else {
+                console.error('Day count span not found in selectedDateDiv.');
+            }
+        } else {
+            console.error('selectedDateDiv is not set.');
+        }
+        return null;
 
     }
 
@@ -192,7 +225,7 @@
             tripLocationElement.innerHTML = `
             <div class="placeNameContainer">
                 <input type="text" class="placeNameInput" value="${place.place_name}" readonly />
-                <button type="button" onclick="removeElement(this.parentNode)">삭제</button>
+<!--                <button type="button" onclick="removeElement(this.parentNode)">삭제</button>-->
             </div>
             <input type="hidden" class="longitudeInput" value="${formattedLongitude}" />
             <input type="hidden" class="latitudeInput" value="${formattedLatitude}" />
@@ -208,28 +241,45 @@
         $('#menu_wrap').hide();
     }
 
-    function removeElement(element) {
-        // // element는 trip-location div
-        // const locationId = element.dataset.id;
-        //
-        // // 화면에서 요소 제거
-        // element.parentNode.removeChild(element);
+    /**
+     * 여행 장소 삭제
+     * HTML에서 제거 후 날짜 카운트 업데이트
+     * @param element
+     */
+    // function removeElement(element) {
+    //     // // element는 trip-location div
+    //     // const locationId = element.dataset.id;
+    //     //
+    //     // // 화면에서 요소 제거
+    //     // element.parentNode.removeChild(element);
+    //
+    //     // `element`는 삭제 버튼이 포함된 `placeNameContainer`의 참조
+    //     const tripLocationElement = element.closest('.trip-location');
+    //     if (tripLocationElement) {
+    //         tripLocationElement.remove();
+    //     }
+    //
+    //     updateDayCount();
+    // }
 
-        // `element`는 삭제 버튼이 포함된 `placeNameContainer`의 참조
-        const tripLocationElement = element.closest('.trip-location');
-        if (tripLocationElement) {
-            tripLocationElement.remove();
-        }
+    /**
+     * 장소 상세 HTML 생성
+     * @param tripLocationData
+     * @param dayNum
+     * @param placeIndex
+     * @returns {string}
+     */
+    function createTripLocationHtml(tripLocationData, dayNum, placeIndex) {
 
-        updateDayCount();
-    }
+        // 장소의 고유 ID 생성 (ex. 몇일차-몇번째장소: 1-1, 1-2, 2-1, ..) 나중에 삭제 시 같은 장소 겹침 문제 해결 위해 고유 ID 지정
+        const uniqueId = `${dayNum}-${placeIndex}`;
 
-    function createTripLocationHtml(tripLocationData) {
         return `
         <div class="trip-location" data-id="${tripLocationData.id || ''}">
           <div class="placeNameContainer">
+            <span id="${uniqueId}">${placeIndex}</span>
             <input type="text" class="placeNameInput" placeholder="장소 이름" value="${tripLocationData.placeName || ''}">
-            <button type="button" onclick="removeElement(this.parentNode)">삭제</button>
+            <button type="button" onclick="handleRemoveBtnClick(event, '${uniqueId}', ${tripLocationData.latitude}, ${tripLocationData.longitude})">삭제</button>
           </div>
           <input type="hidden" class="latitudeInput" placeholder="위도" value="${tripLocationData.latitude || ''}">
           <input type="hidden" class="longitudeInput" placeholder="경도" value="${tripLocationData.longitude || ''}">
@@ -237,6 +287,9 @@
       `;
     }
 
+    /**
+     * 여행 데이터 가져와서 HTML에 채워넣음
+     */
     function fetchTripData() {
         fetch(`/api/trips/${tripId}`)
             .then(response => response.json())
@@ -249,6 +302,9 @@
             });
     }
 
+    /**
+     * 날짜 카운트 업데이트 (Day 숫자 업데이트)
+     */
     function updateDayCount() {
         const tripDateInputs = document.querySelectorAll('.tripDateInput');
         tripDateInputs.forEach((input, index) => {
@@ -272,13 +328,10 @@
     const tripId = window.location.pathname.split('/').pop();
     fetchTripData();
 
-    // $(document).ready(function () {
-    //     // 페이지 로드 시 tripId에 해당하는 장소 데이터를 읽어와 지도에 마커로 표시
-    //     loadSavedPlaces(tripId);
-    // })
-
-    // // 선택 완료 버튼 클릭 이벤트
-    // document.getElementById('completeBtn').addEventListener('click', handleSelectCompleteBtnClick);
+    // 창 닫기 버튼 클릭 시 #menu_wrap 숨기기
+    document.getElementById('closeBtn').addEventListener('click', function() {
+        $('#menu_wrap').hide();
+    });
 </script>
 <script type="text/javascript"
         src="//dapi.kakao.com/v2/maps/sdk.js?appkey=c60fdc23b01e5e1886e831583b4cefb0&libraries=services"></script>

--- a/src/main/resources/templates/trip/updatetrip.html
+++ b/src/main/resources/templates/trip/updatetrip.html
@@ -11,6 +11,7 @@
 <body>
 <div class="container">
     <div class="form_wrap">
+        <a href="" class="backLink">↩️ 일정으로 돌아가기(경로 추가 필요)</a>
         <form id="tripForm">
             <h1>여행 일정 수정</h1>
             <label for="tripName">여행 이름</label>

--- a/src/main/resources/templates/trip/updatetrip.html
+++ b/src/main/resources/templates/trip/updatetrip.html
@@ -58,6 +58,8 @@
 
 <script>
     let tripDatesCounter = 0;
+    let selectedDateDiv = null;
+    let selectedPlaces = [];
 
     document.getElementById('tripForm').addEventListener('submit', function (event) {
         event.preventDefault();
@@ -121,6 +123,24 @@
           ${tripDateData.tripLocations ? tripDateData.tripLocations.map(loc => createTripLocationHtml(loc)).join('') : ''}
         </div>
         <button type="button" onclick="addTripLocation(this.parentNode)">장소 추가</button>
+
+        <!-- 이 날짜의 장소 목록 및 검색 기능 -->
+        <div id="menu_wrap_${tripDateId}" class="menu_wrap" style="display: none;">
+            <div class="option">
+                <div>
+                    <form onsubmit="searchPlaces(${tripDateId}); return false;">
+                        키워드 : <input type="text" value="부산 맛집" id="keyword_${tripDateId}" size="15">
+                        <button type="submit">검색하기</button>
+                    </form>
+                </div>
+            </div>
+            <div>
+                <button type="button" onclick="handleSelectCompleteBtnClick(${tripDateId})">선택 완료</button>
+            </div>
+            <hr>
+            <ul id="placesList_${tripDateId}"></ul>
+            <div id="pagination_${tripDateId}"></div>
+        </div>
       `;
 
         document.getElementById('tripDatesContainer').appendChild(tripDateElement);
@@ -256,11 +276,16 @@
     const tripId = window.location.pathname.split('/').pop();
     fetchTripData();
 
+    // $(document).ready(function () {
+    //     // 페이지 로드 시 tripId에 해당하는 장소 데이터를 읽어와 지도에 마커로 표시
+    //     loadSavedPlaces(tripId);
+    // })
+
     // 선택 완료 버튼 클릭 이벤트
     document.getElementById('completeBtn').addEventListener('click', handleSelectCompleteBtnClick);
 </script>
 <script type="text/javascript"
         src="//dapi.kakao.com/v2/maps/sdk.js?appkey=c60fdc23b01e5e1886e831583b4cefb0&libraries=services"></script>
-<script src="/js/map.js"></script>
+<script src="/js/updatetrip.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/trip/updatetrip.html
+++ b/src/main/resources/templates/trip/updatetrip.html
@@ -10,6 +10,7 @@
 </head>
 <body>
 <div class="container">
+    <!-- 여행 일정 생성 영역 -->
     <div class="form_wrap">
         <a href="" class="backLink">↩️ 일정으로 돌아가기(경로 추가 필요)</a>
         <form id="tripForm">
@@ -30,6 +31,8 @@
             <button type="submit" id="editButton">수정</button>
         </form>
     </div>
+
+    <!-- 지도 영역 -->
     <div class="map_wrap">
         <div id="map"></div>
 
@@ -39,13 +42,11 @@
                 <div>
                     <!-- 검색 폼 제출 시 searchPlaces() 호출 -->
                     <form onsubmit="searchPlaces(); return false;">
-                        키워드 : <input type="text" value="부산 맛집" id="keyword" size="15">
+                        <input type="text" placeholder="장소명을 입력해주세요." id="keyword" size="15">
                         <button type="submit" id="searchBtn">검색하기</button>
                     </form>
+                    <button type="button" id="closeBtn">창 닫기</button>
                 </div>
-            </div>
-            <div>
-                <button type="button" id="completeBtn">선택 완료</button>
             </div>
             <hr>
             <!-- 장소 목록을 표시할 리스트 -->
@@ -58,8 +59,9 @@
 
 <script>
     let tripDatesCounter = 0;
+    let markers = {};
+    let selectedPlaces = {};
     let selectedDateDiv = null;
-    let selectedPlaces = [];
 
     document.getElementById('tripForm').addEventListener('submit', function (event) {
         event.preventDefault();
@@ -122,49 +124,43 @@
         <div class="trip-locations">
           ${tripDateData.tripLocations ? tripDateData.tripLocations.map(loc => createTripLocationHtml(loc)).join('') : ''}
         </div>
-        <button type="button" onclick="addTripLocation(this.parentNode)">장소 추가</button>
-
-        <!-- 이 날짜의 장소 목록 및 검색 기능 -->
-        <div id="menu_wrap_${tripDateId}" class="menu_wrap" style="display: none;">
-            <div class="option">
-                <div>
-                    <form onsubmit="searchPlaces(${tripDateId}); return false;">
-                        키워드 : <input type="text" value="부산 맛집" id="keyword_${tripDateId}" size="15">
-                        <button type="submit">검색하기</button>
-                    </form>
-                </div>
-            </div>
-            <div>
-                <button type="button" onclick="handleSelectCompleteBtnClick(${tripDateId})">선택 완료</button>
-            </div>
-            <hr>
-            <ul id="placesList_${tripDateId}"></ul>
-            <div id="pagination_${tripDateId}"></div>
-        </div>
+        <button type="button" onclick="addTripLocation(this)">장소 추가</button>
       `;
 
         document.getElementById('tripDatesContainer').appendChild(tripDateElement);
+
+        // 받아온 데이터를 기반으로 selectedPlaces 객체 초기화
+        const dayNum = tripDateId + 1;
+        if (tripDateData.tripLocations) {   // tripDateData의 tripLocations이 존재한다면
+            selectedPlaces[dayNum] = tripDateData.tripLocations.map(loc => ({   // 배열을 순회하면서 객체에 할당
+                placeName: loc.placeName,
+                latitude: loc.latitude,
+                longitude: loc.longitude
+            }));
+        } else {    // tripDateData의 tripLocations이 존재하지 않는다면 해당 날짜에는 장소가 없으니 빈 배열로 초기화
+            selectedPlaces[dayNum] = [];
+        }
+
+        // 받아온 데이터를 기반으로 markers 객체 초기화
+        if (tripDateData.tripLocations) {
+            markers[dayNum] = tripDateData.tripLocations.map(loc => ({  // 배열을 순회하면서 객체에 할당
+                latitude: loc.latitude,
+                longitude: loc.longitude
+            }));
+        } else { // tripDateData의 tripLocations이 존재하지 않는다면 해당 날짜에는 마커가 없으니 빈 배열로 초기화
+            markers[dayNum] = [];
+        }
+
+        console.log('update --- selectedPlaces : {}', selectedPlaces);
+        console.log('update --- markers : {}', markers);
     }
 
-    function addTripLocation(tripDateElement, tripLocationData = {}) {
-        // 현재 선택된 날짜 div
-        selectedDateDiv = tripDateElement;
-
+    function addTripLocation(button) {
+        // 장소 추가 버튼을 누를 시 menu_wrap이 보이도록 설정
         document.getElementById('menu_wrap').style.display = 'block';
-        //
-        // const tripLocationElement = document.createElement('div');
-        // tripLocationElement.className = 'trip-location';
-        // tripLocationElement.dataset.id = tripLocationData.id || '';
 
-      //   tripLocationElement.innerHTML = `
-      //   <input type="text" class="placeNameInput" placeholder="장소 이름" value="${tripLocationData.placeName || ''}">
-      //   <input type="text" class="latitudeInput" placeholder="위도" value="${tripLocationData.latitude || ''}">
-      //   <input type="text" class="longitudeInput" placeholder="경도" value="${tripLocationData.longitude || ''}">
-      //   <button type="button" onclick="removeElement(this.parentNode)">삭제</button>
-      // `;
-      //   tripLocationElement.innerHTML = ``;
-      //
-      //   tripDateElement.querySelector('.trip-locations').appendChild(tripLocationElement);
+        selectedDateDiv = button.closest('.tripDate');
+
     }
 
     function handleSelectCompleteBtnClick() {
@@ -281,8 +277,8 @@
     //     loadSavedPlaces(tripId);
     // })
 
-    // 선택 완료 버튼 클릭 이벤트
-    document.getElementById('completeBtn').addEventListener('click', handleSelectCompleteBtnClick);
+    // // 선택 완료 버튼 클릭 이벤트
+    // document.getElementById('completeBtn').addEventListener('click', handleSelectCompleteBtnClick);
 </script>
 <script type="text/javascript"
         src="//dapi.kakao.com/v2/maps/sdk.js?appkey=c60fdc23b01e5e1886e831583b4cefb0&libraries=services"></script>


### PR DESCRIPTION
### 설명
- 여행 일정 생성 시 장소를 전체 15개가 아닌 날짜별로 최대 15개까지 선택 가능하도록 수정했습니다.
- 마커 번호가 날짜별로 1~15까지 이어집니다.
- 여행 일정 수정 시 저장된 장소를 지도에 마커로 표시했습니다.
- 일정 생성 화면에서 장소 삭제 시 장소 배열, 마커 배열에서 삭제되고 장소 번호 변경과 화면에 반영됩니다.
- 일정 수정 화면에서 장소 삭제 시 장소 번호 변경이 화면에 반영됩니다.

### 관련 이슈
Closes #41 
Closes #69 
Closes #70 

### 변경 유형
- [x] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트

### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.

### 추가 설명
- 날짜별로 마커 색상을 다르게 해 가시성을 높일 예정입니다.
