### PR TITLE
fix: User 상태 추가 + 회원 탈퇴 오류

### DIFF
--- a/src/main/java/com/example/omg_project/domain/user/entity/User.java
+++ b/src/main/java/com/example/omg_project/domain/user/entity/User.java
@@ -47,6 +47,9 @@ public class User {
     @Column(nullable = false)
     private String gender; // 성별
 
+    @Column(nullable = false)
+    private String status = "ACTIVE"; // 기본값 ACTIVE
+
     private String filename; // 이미지 파일 이름
 
     private String filepath; // 이미지 파일 경로

--- a/src/main/java/com/example/omg_project/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/omg_project/domain/user/service/impl/UserServiceImpl.java
@@ -2,6 +2,9 @@ package com.example.omg_project.domain.user.service.impl;
 
 import com.example.omg_project.domain.role.entity.Role;
 import com.example.omg_project.domain.role.repository.RoleRepository;
+import com.example.omg_project.domain.trip.entity.Trip;
+import com.example.omg_project.domain.trip.repository.TripRepository;
+import com.example.omg_project.domain.trip.service.impl.TripServiceImpl;
 import com.example.omg_project.domain.user.dto.request.Oauth2LoginRequest;
 import com.example.omg_project.domain.user.dto.request.UserEditRequest;
 import com.example.omg_project.domain.user.dto.request.UserPasswordChangeRequest;
@@ -22,6 +25,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +35,8 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final RoleRepository roleRepository;
+    private final TripServiceImpl tripServiceImpl;
+    private final TripRepository tripRepository;
 
     /**
      * 회원가입 메서드
@@ -38,15 +44,15 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void signUp(UserSignUpRequest userSignUpDto) {
-        if (!userSignUpDto.getPassword().equals(userSignUpDto.getPasswordCheck())) {
-            throw new RuntimeException("비밀번호가 다릅니다.");
-        }
-        if (userRepository.existsByUsername(userSignUpDto.getUsername())) {
-            throw new RuntimeException("이메일이 존재합니다.");
-        }
-        if (userRepository.existsByUsernick(userSignUpDto.getUsernick())) {
-            throw new RuntimeException("닉네임이 존재합니다.");
-        }
+//        if (!userSignUpDto.getPassword().equals(userSignUpDto.getPasswordCheck())) {
+//            throw new RuntimeException("비밀번호가 다릅니다.");
+//        }
+//        if (userRepository.existsByUsername(userSignUpDto.getUsername())) {
+//            throw new RuntimeException("이메일이 존재합니다.");
+//        }
+//        if (userRepository.existsByUsernick(userSignUpDto.getUsernick())) {
+//            throw new RuntimeException("닉네임이 존재합니다.");
+//        }
 
         Role role = roleRepository.findByName("ROLE_USER")
                 .orElseThrow(() -> new RuntimeException("User 역할이 없습니다."));
@@ -61,6 +67,7 @@ public class UserServiceImpl implements UserService {
                 .phoneNumber(userSignUpDto.getPhoneNumber())
                 .gender(userSignUpDto.getGender())
                 .registrationDate(LocalDateTime.now())
+                .status("ACTIVE") // 상태 추가
                 .build();
 
         userRepository.save(user);
@@ -85,10 +92,28 @@ public class UserServiceImpl implements UserService {
         Optional<User> userOptional = userRepository.findById(userId);
         if (userOptional.isPresent()) {
             User user = userOptional.get();
-            userRepository.delete(user);
+            String newEmail = generateUnique(user.getUsername());
+            String newUserNick = generateUnique(user.getUsernick());
+
+            user.setStatus("DEACTIVATED"); // 상태를 DEACTIVATED로 변경
+            user.setUsername(newEmail);
+            user.setUsernick(newUserNick);
+
+            List<Trip> trips = tripRepository.findByUserId(userId);
+            for (Trip trip : trips) {
+                tripServiceImpl.deleteTrip(trip.getId());
+            }
+            userRepository.save(user);
+
+            //userRepository.delete(user);
         } else {
             throw new RuntimeException("삭제할 사용자가 존재하지 않습니다.");
         }
+    }
+    // 탈퇴 시 유니크한 username 부여
+    public static String generateUnique(String email) {
+        String uniqueId = UUID.randomUUID().toString().substring(0, 8);
+        return email + "_" + uniqueId ;
     }
 
     /**

--- a/src/main/java/com/example/omg_project/global/oauth2/service/CustomOauth2UserService.java
+++ b/src/main/java/com/example/omg_project/global/oauth2/service/CustomOauth2UserService.java
@@ -89,6 +89,7 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
                 .gender("default")
                 .registrationDate(LocalDateTime.now())
                 .usernick(oAuth2Response.getEmail())
+                .status("ACTIVE")
                 .build();
         userRepository.save(newUser);
 


### PR DESCRIPTION
### 설명
- User 엔티티 -> 상태(ACTIVE, DEACTIVATED) 추가

### 관련 이슈
Closes

### 변경 유형
- [ ] 버그 수정
- [ ] 새로운 기능
- [ ] 코드 개선
- [ ] 문서 업데이트

### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [ ] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [ ] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.

### 추가 설명
case 1. 일정 생성 후 아무것도 작성 안 한 상태
- 탈퇴 가능 
- 이때 일행 모집 게시글에 글을 올렸는데 탈퇴를 해도 그 게시글이 삭제 안되고 남아있음
- 댓글도 그대로 남아있음

case 2. 일정 생성 후 무언가 작업 한 상태
- 채팅방에 본인 혹은 다른 사용자가 채팅을 치거나 자신이 올린 게시글에 다른 사용자가 댓글을 남긴 경우 오류 발생
- 외래 키 제약 조건 위반 오류

** 회원 탈퇴 로직 
user -> service -> impl -> UserServiceImpl.java

** 댓글이나 게시글 삭제하면 디비에서 삭제가 되어야 하는데 현재 삭제가 안되고 남아있습니다.