### PR TITLE
[#110] 회원 탈퇴 시 채팅 메시지, 댓글, 대댓글 삭제안되는 문제 해결

### DIFF
--- a/src/main/java/com/example/omg_project/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/omg_project/domain/chat/entity/ChatRoom.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.Set;
+
 @Entity
 @Table(name = "chat_rooms")
 @Getter
@@ -14,4 +16,7 @@ public class ChatRoom {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ChatMessage> chatMessages;
 }

--- a/src/main/java/com/example/omg_project/domain/joinpost/entity/JoinPostComment.java
+++ b/src/main/java/com/example/omg_project/domain/joinpost/entity/JoinPostComment.java
@@ -38,7 +38,7 @@ public class JoinPostComment {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "joinPostComment", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "joinPostComment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<JoinPostReply> joinPostReplies;
 
     // 엔티티가 영속화되기 전에 실행되는 메서드

--- a/src/main/java/com/example/omg_project/domain/joinpost/repository/JoinPostCommentRepository.java
+++ b/src/main/java/com/example/omg_project/domain/joinpost/repository/JoinPostCommentRepository.java
@@ -1,6 +1,7 @@
 package com.example.omg_project.domain.joinpost.repository;
 
 import com.example.omg_project.domain.joinpost.entity.JoinPostComment;
+import com.example.omg_project.domain.reviewpost.entity.ReviewPostComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,4 +9,6 @@ import java.util.List;
 public interface JoinPostCommentRepository extends JpaRepository<JoinPostComment, Long> {
     // 특정 게시글에 대한 모든 댓글 조회
     List<JoinPostComment> findAllByJoinPostId(Long joinPostId);
+
+    List<JoinPostComment> findByUserId(Long userId);
 }

--- a/src/main/java/com/example/omg_project/domain/joinpost/repository/JoinPostReplyRepository.java
+++ b/src/main/java/com/example/omg_project/domain/joinpost/repository/JoinPostReplyRepository.java
@@ -1,5 +1,6 @@
 package com.example.omg_project.domain.joinpost.repository;
 
+import com.example.omg_project.domain.joinpost.entity.JoinPostComment;
 import com.example.omg_project.domain.joinpost.entity.JoinPostReply;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,5 @@ import java.util.List;
 public interface JoinPostReplyRepository extends JpaRepository<JoinPostReply, Long> {
     // 특정 댓글에 대한 모든 대댓글 조회
     List<JoinPostReply> findAllByJoinPostCommentId(Long joinPostCommentId);
+    List<JoinPostReply> findByUserId(Long userId);
 }

--- a/src/main/java/com/example/omg_project/domain/joinpost/service/JoinPostCommentService.java
+++ b/src/main/java/com/example/omg_project/domain/joinpost/service/JoinPostCommentService.java
@@ -1,6 +1,7 @@
 package com.example.omg_project.domain.joinpost.service;
 
 import com.example.omg_project.domain.joinpost.dto.JoinPostCommentDto;
+import com.example.omg_project.domain.reviewpost.entity.ReviewPostComment;
 
 import java.util.List;
 
@@ -13,4 +14,5 @@ public interface JoinPostCommentService {
     JoinPostCommentDto.Response updateComment(Long commentId,JoinPostCommentDto.Request commentRequest);
     // 일행 댓글 삭제
     void deleteComment(Long commentId);
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/omg_project/domain/joinpost/service/JoinPostReplyService.java
+++ b/src/main/java/com/example/omg_project/domain/joinpost/service/JoinPostReplyService.java
@@ -13,4 +13,5 @@ public interface JoinPostReplyService {
     JoinPostReplyDto.Response updateReply(Long replyId, JoinPostReplyDto.Request replyRequest);
     // 일행 모집 대댓글 삭제
     void deleteReply(Long replyId);
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/omg_project/domain/joinpost/service/impl/JoinPostCommentServiceImpl.java
+++ b/src/main/java/com/example/omg_project/domain/joinpost/service/impl/JoinPostCommentServiceImpl.java
@@ -6,6 +6,7 @@ import com.example.omg_project.domain.joinpost.entity.JoinPostComment;
 import com.example.omg_project.domain.joinpost.repository.JoinPostCommentRepository;
 import com.example.omg_project.domain.joinpost.repository.JoinPostRepository;
 import com.example.omg_project.domain.joinpost.service.JoinPostCommentService;
+import com.example.omg_project.domain.reviewpost.entity.ReviewPostComment;
 import com.example.omg_project.domain.user.entity.User;
 import com.example.omg_project.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -63,5 +64,10 @@ public class JoinPostCommentServiceImpl implements JoinPostCommentService {
         joinPostCommentRepository.deleteById(commentId);
     }
 
-
+    @Override
+    @Transactional
+    public void deleteByUserId(Long userId) {
+        List<JoinPostComment> joinPostComments = joinPostCommentRepository.findByUserId(userId);
+        joinPostCommentRepository.deleteAll(joinPostComments);
+    }
 }

--- a/src/main/java/com/example/omg_project/domain/joinpost/service/impl/JoinPostReplyServiceImpl.java
+++ b/src/main/java/com/example/omg_project/domain/joinpost/service/impl/JoinPostReplyServiceImpl.java
@@ -62,4 +62,11 @@ public class JoinPostReplyServiceImpl implements JoinPostReplyService {
     public void deleteReply(Long replyId) {
         joinPostReplyRepository.deleteById(replyId);
     }
+
+    @Override
+    @Transactional
+    public void deleteByUserId(Long userId) {
+        List<JoinPostReply> joinPostReplies = joinPostReplyRepository.findByUserId(userId);
+        joinPostReplyRepository.deleteAll(joinPostReplies);
+    }
 }

--- a/src/main/java/com/example/omg_project/domain/reviewpost/entity/ReviewPostComment.java
+++ b/src/main/java/com/example/omg_project/domain/reviewpost/entity/ReviewPostComment.java
@@ -35,7 +35,7 @@ public class ReviewPostComment {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "reviewPostComment", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "reviewPostComment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewPostReply> reviewPostReplies;
 
     // 엔티티가 영속화되기 전에 실행되는 메서드

--- a/src/main/java/com/example/omg_project/domain/reviewpost/repository/ReviewPostCommentRepository.java
+++ b/src/main/java/com/example/omg_project/domain/reviewpost/repository/ReviewPostCommentRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface ReviewPostCommentRepository extends JpaRepository<ReviewPostComment, Long> {
     // 특정 게시글에 대한 모든 댓글 조회
     List<ReviewPostComment> findAllByReviewPostId(Long reviewPostId);
+    List<ReviewPostComment> findByUserId(Long userId);
+
 }

--- a/src/main/java/com/example/omg_project/domain/reviewpost/repository/ReviewPostReplyRepository.java
+++ b/src/main/java/com/example/omg_project/domain/reviewpost/repository/ReviewPostReplyRepository.java
@@ -1,5 +1,6 @@
 package com.example.omg_project.domain.reviewpost.repository;
 
+import com.example.omg_project.domain.joinpost.entity.JoinPostReply;
 import com.example.omg_project.domain.reviewpost.entity.ReviewPostReply;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,5 @@ import java.util.List;
 public interface ReviewPostReplyRepository extends JpaRepository<ReviewPostReply, Long> {
     // 특정 댓글에 대한 모든 대댓글 조회
     List<ReviewPostReply> findAllByReviewPostCommentId(Long reviewPostCommentId);
+    List<ReviewPostReply> findByUserId(Long userId);
 }

--- a/src/main/java/com/example/omg_project/domain/reviewpost/service/ReviewPostCommentService.java
+++ b/src/main/java/com/example/omg_project/domain/reviewpost/service/ReviewPostCommentService.java
@@ -13,4 +13,5 @@ public interface ReviewPostCommentService {
     ReviewPostCommentDto.Response updateComment(Long commentId,ReviewPostCommentDto.Request commentRequest);
     // 후기 댓글 삭제
     void deleteComment(Long commentId);
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/omg_project/domain/reviewpost/service/ReviewPostReplyService.java
+++ b/src/main/java/com/example/omg_project/domain/reviewpost/service/ReviewPostReplyService.java
@@ -13,4 +13,5 @@ public interface ReviewPostReplyService {
     ReviewPostReplyDto.Response updateReply(Long replyId, ReviewPostReplyDto.Request replyRequest);
     // 후기 대댓글 삭제
     void deleteReply(Long replyId);
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/omg_project/domain/reviewpost/service/impl/ReviewPostCommentServiceImpl.java
+++ b/src/main/java/com/example/omg_project/domain/reviewpost/service/impl/ReviewPostCommentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.omg_project.domain.reviewpost.service.impl;
 
+import com.example.omg_project.domain.joinpost.entity.JoinPostComment;
 import com.example.omg_project.domain.reviewpost.dto.ReviewPostCommentDto;
 import com.example.omg_project.domain.reviewpost.entity.ReviewPost;
 import com.example.omg_project.domain.reviewpost.entity.ReviewPostComment;
@@ -63,5 +64,10 @@ public class ReviewPostCommentServiceImpl implements ReviewPostCommentService {
         reviewPostCommentRepository.deleteById(commentId);
     }
 
-
+    @Override
+    @Transactional
+    public void deleteByUserId(Long userId) {
+        List<ReviewPostComment> reviewPostComments = reviewPostCommentRepository.findByUserId(userId);
+        reviewPostCommentRepository.deleteAll(reviewPostComments);
+    }
 }

--- a/src/main/java/com/example/omg_project/domain/reviewpost/service/impl/ReviewPostReplyServiceImpl.java
+++ b/src/main/java/com/example/omg_project/domain/reviewpost/service/impl/ReviewPostReplyServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.omg_project.domain.reviewpost.service.impl;
 
+import com.example.omg_project.domain.joinpost.entity.JoinPostReply;
 import com.example.omg_project.domain.reviewpost.dto.ReviewPostReplyDto;
 import com.example.omg_project.domain.reviewpost.entity.ReviewPostComment;
 import com.example.omg_project.domain.reviewpost.entity.ReviewPostReply;
@@ -61,5 +62,12 @@ public class ReviewPostReplyServiceImpl implements ReviewPostReplyService {
     @Transactional
     public void deleteReply(Long replyId) {
         reviewPostReplyRepository.deleteById(replyId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteByUserId(Long userId) {
+        List<ReviewPostReply> reviewPostReplies = reviewPostReplyRepository.findByUserId(userId);
+        reviewPostReplyRepository.deleteAll(reviewPostReplies);
     }
 }

--- a/src/main/java/com/example/omg_project/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/omg_project/domain/user/service/impl/UserServiceImpl.java
@@ -1,5 +1,12 @@
 package com.example.omg_project.domain.user.service.impl;
 
+import com.example.omg_project.domain.joinpost.entity.JoinPostComment;
+import com.example.omg_project.domain.joinpost.service.JoinPostCommentService;
+import com.example.omg_project.domain.joinpost.service.JoinPostReplyService;
+import com.example.omg_project.domain.joinpost.service.impl.JoinPostReplyServiceImpl;
+import com.example.omg_project.domain.reviewpost.entity.ReviewPostComment;
+import com.example.omg_project.domain.reviewpost.service.ReviewPostCommentService;
+import com.example.omg_project.domain.reviewpost.service.ReviewPostReplyService;
 import com.example.omg_project.domain.role.entity.Role;
 import com.example.omg_project.domain.role.repository.RoleRepository;
 import com.example.omg_project.domain.trip.entity.Trip;
@@ -37,6 +44,10 @@ public class UserServiceImpl implements UserService {
     private final RoleRepository roleRepository;
     private final TripServiceImpl tripServiceImpl;
     private final TripRepository tripRepository;
+    private final ReviewPostCommentService reviewPostCommentService;
+    private final ReviewPostReplyService reviewPostReplyService;
+    private final JoinPostCommentService joinPostCommentService;
+    private final JoinPostReplyService joinPostReplyService;
 
     /**
      * 회원가입 메서드
@@ -103,6 +114,13 @@ public class UserServiceImpl implements UserService {
             for (Trip trip : trips) {
                 tripServiceImpl.deleteTrip(trip.getId());
             }
+
+            // 작성한 댓글과 대댓글 삭제
+            joinPostCommentService.deleteByUserId(user.getId());
+            joinPostReplyService.deleteByUserId(user.getId());
+            reviewPostCommentService.deleteByUserId(user.getId());
+            reviewPostReplyService.deleteByUserId(user.getId());
+
             userRepository.save(user);
 
             //userRepository.delete(user);


### PR DESCRIPTION
### 설명
- 회원 탈퇴 시 여행과 채팅방을 삭제하는데 채팅방 삭제 시 채팅 메시지도 함께 삭제되도록 연관 관계 설정
- 회원 탈퇴 시 회원이 삭제 되는게 아니라 회원의 이름, 이메일, 상태가 바뀌는것
  - 즉, 로직에 trip을 수동으로 삭제 함으로써 게시글, 채팅방이 삭제된 것
  - 마찬가지로 댓글, 대댓글이 지워지는 것도 user가 삭제되는 것이 아니므로 user 엔티티의 연관관계와 상관 없음 -> 직접 수동으로 삭제해줌으로써 구현
- ReviewPostComment와 JoinPostCommet에 ```orphanRemoval = true``` 를 추가했습니다.

### 관련 이슈
Closes #110

### 변경 유형
- [x] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트

### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.

### 추가 설명

