### PR TITLE
[#111] CKEditor 이미지 업로드 구현 & joinPost, reviewPost 테이블 데이터 타입 수정

### DIFF
--- a/src/main/java/com/example/omg_project/domain/joinpost/entity/JoinPost.java
+++ b/src/main/java/com/example/omg_project/domain/joinpost/entity/JoinPost.java
@@ -33,7 +33,7 @@ public class JoinPost {
     @Column(nullable = false, length = 100)
     private String title;
 
-    @Column(nullable = false, length = 500)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/omg_project/domain/reviewpost/entity/ReviewPost.java
+++ b/src/main/java/com/example/omg_project/domain/reviewpost/entity/ReviewPost.java
@@ -31,7 +31,7 @@ public class ReviewPost {
     @Column(nullable = false, length = 100)
     private String title;
 
-    @Column(nullable = false, length = 500)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/omg_project/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/omg_project/domain/user/controller/UserController.java
@@ -123,7 +123,7 @@ public class UserController {
 
                 // 프로필 이미지 파일을 선택했을 경우, 프로필 이미지 업데이트
                 if (profileImage != null && !profileImage.isEmpty()) {
-                    String imageUrl = imageService.upload(profileImage);
+                    String imageUrl = imageService.upload(profileImage, "UserProfileImage");
                     userService.updateProfileImage(username, imageUrl);
                 }
                 return ResponseEntity.ok("회원정보가 수정되었습니다.");

--- a/src/main/java/com/example/omg_project/global/image/controller/ImageController.java
+++ b/src/main/java/com/example/omg_project/global/image/controller/ImageController.java
@@ -3,6 +3,8 @@ package com.example.omg_project.global.image.controller;
 import com.example.omg_project.global.exception.CustomException;
 import com.example.omg_project.global.image.service.ImageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,8 +21,8 @@ public class ImageController {
 
     // CKEditor 이미지 업로드
     @PostMapping("/image/upload")
-    public Map<String, Object> imageUpload(MultipartRequest request){
-        // CKEditor에서 이미지를 올리면 두 가지 응답 값을 받음 (uploaded: 업로드가 잘되었는지, url: 어디에 업로드되었는지)
+    public ResponseEntity<Map<String, Object>> imageUpload(MultipartRequest request){
+        // CKEditor에서 이미지를 올리면 두 가지 응답 값을 받음 (uploaded: 업로드가 잘 되었는지, url: 어디에 업로드되었는지)
         Map<String, Object> responseData = new HashMap<>();
 
         // CKEditor에서 이미지 파일을 보내줄 때 'upload'라는 key에 이미지 파일을 저장해서 보내줌 -> request에서 이미지 파일 뽑아냄
@@ -33,10 +35,12 @@ public class ImageController {
             // 제대로 업로드가 되었다면 uploaded=true와 url 설정 해줌
             responseData.put("uploaded", true);
             responseData.put("url", s3Url);
-            return responseData;
+
+            return ResponseEntity.ok(responseData);
         } catch (CustomException e) {
             responseData.put("uploaded", false);
-            return responseData;
+
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseData);
         }
     }
 }

--- a/src/main/java/com/example/omg_project/global/image/controller/ImageController.java
+++ b/src/main/java/com/example/omg_project/global/image/controller/ImageController.java
@@ -30,7 +30,7 @@ public class ImageController {
 
         try {
             // S3 버킷에 업로드
-            String s3Url = imageService.upload(image);
+            String s3Url = imageService.upload(image, "JoinPost");
 
             // 제대로 업로드가 되었다면 uploaded=true와 url 설정 해줌
             responseData.put("uploaded", true);

--- a/src/main/java/com/example/omg_project/global/image/controller/ImageController.java
+++ b/src/main/java/com/example/omg_project/global/image/controller/ImageController.java
@@ -1,0 +1,42 @@
+package com.example.omg_project.global.image.controller;
+
+import com.example.omg_project.global.exception.CustomException;
+import com.example.omg_project.global.image.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    // CKEditor 이미지 업로드
+    @PostMapping("/image/upload")
+    public Map<String, Object> imageUpload(MultipartRequest request){
+        // CKEditor에서 이미지를 올리면 두 가지 응답 값을 받음 (uploaded: 업로드가 잘되었는지, url: 어디에 업로드되었는지)
+        Map<String, Object> responseData = new HashMap<>();
+
+        // CKEditor에서 이미지 파일을 보내줄 때 'upload'라는 key에 이미지 파일을 저장해서 보내줌 -> request에서 이미지 파일 뽑아냄
+        MultipartFile image = request.getFile("upload");
+
+        try {
+            // S3 버킷에 업로드
+            String s3Url = imageService.upload(image);
+
+            // 제대로 업로드가 되었다면 uploaded=true와 url 설정 해줌
+            responseData.put("uploaded", true);
+            responseData.put("url", s3Url);
+            return responseData;
+        } catch (CustomException e) {
+            responseData.put("uploaded", false);
+            return responseData;
+        }
+    }
+}

--- a/src/main/java/com/example/omg_project/global/image/controller/ImageController.java
+++ b/src/main/java/com/example/omg_project/global/image/controller/ImageController.java
@@ -30,7 +30,7 @@ public class ImageController {
 
         try {
             // S3 버킷에 업로드
-            String s3Url = imageService.upload(image, "JoinPost");
+            String s3Url = imageService.upload(image, "Post");
 
             // 제대로 업로드가 되었다면 uploaded=true와 url 설정 해줌
             responseData.put("uploaded", true);

--- a/src/main/java/com/example/omg_project/global/image/service/ImageService.java
+++ b/src/main/java/com/example/omg_project/global/image/service/ImageService.java
@@ -5,10 +5,11 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 
 public interface ImageService {
-    String upload(MultipartFile image); // 외부에서 사용할 public 메서드
-    String uploadImage(MultipartFile image);
+    String upload(MultipartFile image);
+    String upload(MultipartFile image, String directoryName);  // S3 버킷의 폴더 이름을 포함한 upload 메서드 오버로딩
+    String uploadImage(MultipartFile image, String directoryName);
     void validateImageFileExtention(String filename);
-    String uploadImageToS3(MultipartFile image) throws IOException;
+    String uploadImageToS3(MultipartFile image, String directoryName) throws IOException;
     void deleteImageFromS3(String imageUrl);
     String getKeyFromImageUrl(String imageUrl);
 }

--- a/src/main/java/com/example/omg_project/global/image/service/impl/ImageServiceImpl.java
+++ b/src/main/java/com/example/omg_project/global/image/service/impl/ImageServiceImpl.java
@@ -39,17 +39,28 @@ public class ImageServiceImpl implements ImageService {
 
     /**
      * 외부에서 사용할 public 메서드
-     * 업로드할 이미지를 S3에 업로드하고 URL을 반환
+     * 업로드할 이미지를 S3의 루트 폴더에 업로드하고 URL을 반환
+     * @param image 업로드할 이미지 파일
+     * @return S3에 저장된 이미지 객체의 S3 URL
+     */
+    @Override
+    public String upload(MultipartFile image) {
+        return upload(image, "");
+    }
+
+    /**
+     * 외부에서 사용할 public 메서드
+     * 업로드할 이미지를 S3의 directoryName 폴더에 업로드하고 URL을 반환
      * @param image 업로드할 이미지 파일
      * @return S3에 저장된 이미지 객체의 S3 URL
      * @throws CustomException 파일이 비어있거나 이름이 없는 경우
      */
     @Override
-    public String upload(MultipartFile image) {
+    public String upload(MultipartFile image, String directoryName) {
         if (image.isEmpty() || Objects.isNull(image.getOriginalFilename())) {
             throw new CustomException(ErrorCode.EMPTY_FILE_EXCEPTION);
         }
-        return uploadImage(image);
+        return uploadImage(image, directoryName);
     }
 
     /**
@@ -60,10 +71,10 @@ public class ImageServiceImpl implements ImageService {
      * @throws CustomException 이미지 업로드 중 IOException 발생한 경우
      */
     @Override
-    public String uploadImage(MultipartFile image) {
+    public String uploadImage(MultipartFile image, String directoryName) {
         validateImageFileExtention(image.getOriginalFilename());
         try {
-            return uploadImageToS3(image);
+            return uploadImageToS3(image, directoryName);
         } catch (IOException e) {
             throw new CustomException(ErrorCode.IO_EXCEPTION_ON_IMAGE_UPLOAD);
         }
@@ -97,10 +108,10 @@ public class ImageServiceImpl implements ImageService {
      * @throws CustomException
      */
     @Override
-    public String uploadImageToS3(MultipartFile image) throws IOException {
+    public String uploadImageToS3(MultipartFile image, String directoryName) throws IOException {
         String originalFilename = image.getOriginalFilename();
         String extension = originalFilename.substring(originalFilename.lastIndexOf('.'));
-        String s3FileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename;
+        String s3FileName = directoryName + "/" + UUID.randomUUID().toString().substring(0, 10) + originalFilename;
 
         // 입력 스트림을 통해 파일 데이터 읽어옴
         InputStream is = image.getInputStream();


### PR DESCRIPTION
### 설명
- CKEditor에서 이미지 업로드 시 S3 버킷에 올라가도록 구현했습니다.
- 기존 joinPost, reviewPost 테이블의 content 필드 데이터 타입이 varchar(500)으로 되어있어 용량 초과 문제가 발생해 LONGTEXT 타입으로 변경하였습니다. **(아래 추가 설명에 관련 쿼리 첨부해두었습니다!)**

### 관련 이슈
Closes #111 

### 변경 유형
- [ ] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [ ] 문서 업데이트

### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.

### 추가 설명
- **PR merge 후 아래 1번, 3번만 확인**해주세요. 2번은 이미 커밋에 포함되어있어서 안 하셔도 됩니다.
- 저는 따로 테이블 drop도 안 하고 yml 파일에서 create도 안 했는데 잘 적용 되더라구요.

1. 아래 데이터 타입 변경 쿼리 실행해주세요. (1번만 적용하니 재시작 시 하이버네이트가 다시 varchar(500)으로 되돌려서 2번도 적용했습니다.)
```sql
ALTER TABLE join_posts MODIFY content LONGTEXT NOT NULL;
ALTER TABLE review_posts MODIFY content LONGTEXT NOT NULL;
```
2. 엔티티의 Column 속성을 지정해주었습니다.
```java
@Column(nullable = false, columnDefinition = "LONGTEXT")
private String content;
```
3. desc 쿼리로 잘 적용되었는지 확인해보세요.
```
desc join_posts;
desc review_posts;
```