### PR TITLE
[#146][#149] 여행 일정 생성/수정 페이지 - 여행 날짜 수정 시 장소 순서, 지도에 표시 알맞게 수정 & 여행 데이터 못 읽어오는 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,11 @@ repositories {
     mavenCentral()
 }
 
+// 매개변수 이름 인식문제 해결 (ex) @RequestParam, @PathVariable, ..)
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-parameters"
+}
+
 dependencies {
     // email smtp
     implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/src/main/resources/static/js/createtrip.js
+++ b/src/main/resources/static/js/createtrip.js
@@ -447,13 +447,36 @@ function reorderMarkers(markers, dayNum) {
 }
 
 /**
- * 지도 위에 표시되고 있는 마커를 모두 제거합니다
+ * 지도 위에 표시되고 있는 모든 날짜에 대한 마커를 모두 제거하는 함수
  */
-function removeMarker() {
-    for (let i = 0; i < markers.length; i++) {
-        markers[i].setMap(null);
-    }
-    markers = [];
+function clearAllMarker() {
+    // markers 객체에 저장된 모든 dayNum(key)을 순회하며 각 날짜에 대한 marker 처리
+    Object.keys(markers).forEach(dayNum => {
+        // 각 날짜에 해당하는 markers 배열 순회하며 marker 처리
+        markers[dayNum].forEach(marker => {
+            // 지도에서 마커를 제거
+            marker.setMap(null);
+        });
+        // 마커 배열을 초기화
+        markers[dayNum] = [];
+    });
+    console.log('---clearAllMarker---');
+}
+
+/**
+ * 지도 위에 그려진 모든 폴리라인(선)를 제거하는 함수
+ */
+function clearAllPolyline() {
+    // polyline 객체에 저장된 모든 dayNum(key)을 순회
+    Object.keys(polyline).forEach(dayNum => {
+        if (polyline[dayNum]) {
+            // 지도에서 폴리라인을 제거
+            polyline[dayNum].setMap(null);
+            // 해당 dayNum의 polyline 객체 초기화
+            delete polyline[dayNum];
+        }
+    });
+    console.log('---clearAllPolyline---');
 }
 
 /**

--- a/src/main/resources/static/js/updatetrip.js
+++ b/src/main/resources/static/js/updatetrip.js
@@ -41,23 +41,6 @@ const markerImages = {
 const MAX_LOCATIONS = 15;
 
 /**
- * 마커 이미지 색상과 장소명 앞 span 태그의 글자 색상 연관 짓기
- * @param index
- * @returns {string}
- */
-function getColorCode(index) {
-    const colors = [
-        '#F78181',  // red
-        '#F7D358',  // yellow
-        '#82FA58',  // green
-        '#58FAF4',  // cyan
-        '#58ACFA',  // blue
-        '#9F81F7'   // purple
-    ];
-    return colors[index-1]; // colors는 0부터 시작하고 markerIndex는 1부터 시작하기 때문에 -1 해서 값 맞춰줌
-}
-
-/**
  * 키워드 검색을 요청하는 함수입니다
  * @returns {boolean} - 키워드가 유효하지 않으면 false
  */

--- a/src/main/resources/static/js/updatetrip.js
+++ b/src/main/resources/static/js/updatetrip.js
@@ -38,6 +38,8 @@ const markerImages = {
     6: '/files/markers/marker_number_purple.png'
 }
 
+const MAX_LOCATIONS = 15;
+
 /**
  * 마커 이미지 색상과 장소명 앞 span 태그의 글자 색상 연관 짓기
  * @param index
@@ -138,7 +140,6 @@ function handleSelectBtnClick(event, place, placePosition) {
     }
 
     const locationsContainer = selectedDateDiv.querySelector('.trip-locations');
-    const MAX_LOCATIONS = 15;
 
     if (selectedPlaces[dayNum].length >= MAX_LOCATIONS) {
         alert(`하루에 추가할 수 있는 장소는 최대 ${MAX_LOCATIONS}개입니다.`);
@@ -172,10 +173,8 @@ function handleSelectBtnClick(event, place, placePosition) {
     addSelectedMarker(placePosition, index, dayNum);
     // 마커 번호 재정렬
     reorderMarkers(markers, dayNum);
-
     // 지도 범위 재설정
     setBounds(placePosition);
-
     // 지도에 선 표시
     drawLinePath(dayNum, placePosition);
 }

--- a/src/main/resources/static/js/updatetrip.js
+++ b/src/main/resources/static/js/updatetrip.js
@@ -25,7 +25,7 @@ const ps = new kakao.maps.services.Places();
 // 선을 구성하는 좌표 배열입니다. 이 좌표들을 이어서 선을 표시합니다.
 let linePath = {};
 
-// 폴리라인(선) 객체 배열
+// 폴리라인(선) 객체 (key: dayNum, value: 단일 kakao.maps.Polyline 객체)
 let polyline = {};
 
 // 마커 이미지가 순환되도록 매핑
@@ -213,6 +213,7 @@ function drawLinePath(dayNum, placePosition) {
 
     // 지도에 선을 표시합니다
     polyline[dayNum].setMap(map);
+    console.log('drawLinePath --- polyline: {}', polyline);
 }
 
 /**
@@ -288,10 +289,6 @@ function handleRemoveBtnClick(event, placeUniqueId, placePositionLa, placePositi
         if (pathIndex !== -1) {   // 해당 장소 위치 좌표가 존재한다면
             linePath[dayNum].splice(pathIndex, 1); // 배열에서 해당 좌표 제거. 인덱스부터 1개의 요소 삭제
         }
-
-        console.log('handleRemoveBtnClick --- Selected Places:', selectedPlaces);
-        console.log('handleRemoveBtnClick --- Markers:', markers);
-        console.log('----------');
 
         // 장소와 마커가 삭제된 후, 나머지 요소들의 인덱스와 ID를 업데이트
         updatePlaceIndexes(dayNum);
@@ -430,7 +427,6 @@ function addSelectedMarker(position, idx, dayNum) {
     // markers.push(marker);
     markers[dayNum].push(marker);
     console.log('addSelectedMarker --- markres: {}', markers);
-    console.log('----------');
 
     return marker;
 }
@@ -463,7 +459,6 @@ function addSavedPlacesMarker(latitude, longitude, idx, dayNum) {
     markers[dayNum].push(marker);
     setBounds(new kakao.maps.LatLng(latitude, longitude));
     console.log('addSavedPlacesMarker --- markers: {}', markers);
-    console.log('----------');
 
     return marker;
 }
@@ -493,13 +488,36 @@ function reorderMarkers(markers, dayNum) {
 }
 
 /**
- * 지도 위에 표시되고 있는 마커를 모두 제거합니다
+ * 지도 위에 표시되고 있는 모든 날짜에 대한 마커를 모두 제거하는 함수
  */
-function removeMarker() {
-    for (let i = 0; i < markers.length; i++) {
-        markers[i].setMap(null);
-    }
-    markers = [];
+function clearAllMarker() {
+    // markers 객체에 저장된 모든 dayNum(key)을 순회하며 각 날짜에 대한 marker 처리
+    Object.keys(markers).forEach(dayNum => {
+        // 각 날짜에 해당하는 markers 배열 순회하며 marker 처리
+        markers[dayNum].forEach(marker => {
+            // 지도에서 마커를 제거
+            marker.setMap(null);
+        });
+        // 마커 배열을 초기화
+        markers[dayNum] = [];
+    });
+    console.log('---clearAllMarker---');
+}
+
+/**
+ * 지도 위에 그려진 모든 폴리라인(선)를 제거하는 함수
+ */
+function clearAllPolyline() {
+    // polyline 객체에 저장된 모든 dayNum(key)을 순회
+    Object.keys(polyline).forEach(dayNum => {
+        if (polyline[dayNum]) {
+            // 지도에서 폴리라인을 제거
+            polyline[dayNum].setMap(null);
+            // 해당 dayNum의 polyline 객체 초기화
+            delete polyline[dayNum];
+        }
+    });
+    console.log('---clearAllPolyline---');
 }
 
 /**

--- a/src/main/resources/templates/trip/createtrip.html
+++ b/src/main/resources/templates/trip/createtrip.html
@@ -469,6 +469,14 @@
 
         // 날짜 변경 시 날짜 변경 전에 띄워둔 검색창 숨기기
         $('#menu_wrap').hide();
+
+        // updateTripDates() 호출되면 기존 데이터들 모두 지우기
+        // 추가된 장소 배열인 selectedPlaces 객체 & 폴리라인을 구성하는 좌표 배열인 linePath 객체를 초기화시킴
+        selectedPlaces = {};
+        linePath = {};
+        // 지도 위에 표시되고 있는 마커와 폴리라인을 제거
+        clearAllMarker();
+        clearAllPolyline();
     }
 
     function toggleTripDate(element) {

--- a/src/main/resources/templates/trip/createtrip.html
+++ b/src/main/resources/templates/trip/createtrip.html
@@ -369,6 +369,9 @@
         });
     }
 
+    /**
+     * 여행 일정 폼 제출 처리
+     */
     document.getElementById('tripForm').addEventListener('submit', function (event) {
         event.preventDefault();
 
@@ -430,6 +433,9 @@
             });
     });
 
+    /**
+     * 여행 날짜 업데이트 함수
+     */
     function updateTripDates() {
         const startDate = document.getElementById('startDate').value;
         const endDate = document.getElementById('endDate').value;
@@ -460,6 +466,9 @@
                 console.log(`TripDate added: Day ${dayCount}, Date: ${date.toISOString().split('T')[0]}`);
             }
         }
+
+        // 날짜 변경 시 날짜 변경 전에 띄워둔 검색창 숨기기
+        $('#menu_wrap').hide();
     }
 
     function toggleTripDate(element) {
@@ -467,6 +476,11 @@
         dayContent.classList.toggle('show');
     }
 
+    /**
+     * 장소 추가 버튼 클릭 시 검색창을 열고 해당 날짜 정보를 저장 및 selectedPlaces, markers 객체 초기화
+     * @param button
+     * @returns {null|string}
+     */
     function addLocation(button) {
         // 장소 추가 버튼을 누를 시 menu_wrap이 보이도록 설정
         document.getElementById('menu_wrap').style.display = 'block';

--- a/src/main/resources/templates/trip/updatetrip.html
+++ b/src/main/resources/templates/trip/updatetrip.html
@@ -84,7 +84,7 @@
         </div>
     </div>
 </div>
-<script>
+<script defer>
     const cityCoordinates = {
         "서울": { lat: 37.5665, lng: 126.9780 },
         "부산": { lat: 35.1796, lng: 129.0756 },
@@ -269,6 +269,23 @@
             }
         });
     });
+
+    /**
+     * 마커 이미지 색상과 장소명 앞 span 태그의 글자 색상 연관 짓기
+     * @param index
+     * @returns {string}
+     */
+    function getColorCode(index) {
+        const colors = [
+            '#F78181',  // red
+            '#F7D358',  // yellow
+            '#82FA58',  // green
+            '#58FAF4',  // cyan
+            '#58ACFA',  // blue
+            '#9F81F7'   // purple
+        ];
+        return colors[index-1]; // colors는 0부터 시작하고 markerIndex는 1부터 시작하기 때문에 -1 해서 값 맞춰줌
+    }
 
     /**
      * fetchTripData에서 호출되어 각 여행 날짜 동적으로 생성
@@ -744,6 +761,6 @@
 </script>
 <script type="text/javascript"
         src="//dapi.kakao.com/v2/maps/sdk.js?appkey=c60fdc23b01e5e1886e831583b4cefb0&libraries=services"></script>
-<script src="/js/updatetrip.js"></script>
+<script src="/js/updatetrip.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates/trip/updatetrip.html
+++ b/src/main/resources/templates/trip/updatetrip.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="ko">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -60,9 +59,11 @@
             <!-- 페이지네이션을 표시 -->
             <div id="pagination"></div>
         </div>
-        <button id="toggleButton" class="toggleButton">접기</button> <!-- 접기/펼치기 버튼을 창 밖으로 이동 -->
+        <!-- 접기/펼치기 버튼 -->
+        <button id="toggleButton" class="toggleButton">접기</button>
+        <!-- 여행 명소 추천 컨테이너 -->
         <div class="filter_wrap" id="filter_wrap">
-            <h3 id="filterTitle">여행 명소 추천</h3> <!-- 제목 추가 -->
+            <h3 id="filterTitle">여행 명소 추천</h3>
             <div id="filterContent">
                 <div id="filterButtons">
                     <button type="button" onclick="filterPlaces(12)">관광지</button>
@@ -75,6 +76,7 @@
                 </div>
                 <br>
                 <hr>
+                <!-- 필터링된 장소 리스트를 표시할 컨테이너 -->
                 <div id="filteredPlacesListContainer">
                     <ul id="filteredPlacesList"></ul>
                 </div>
@@ -208,15 +210,16 @@
     };
 
     let tripDatesCounter = 0;
-    let markers = {};
-    let selectedPlaces = {};
-    let selectedDateDiv = null;
+    let markers = {};   // 마커를 저장할 객체
+    let selectedPlaces = {};    // 선택된 장소를 저장할 객체
+    let selectedDateDiv = null; // 선택된 날짜의 div 요소
 
     // 수정 버튼 클릭 이벤트 핸들러
     document.getElementById('editButton').addEventListener('click', function(event) {
         event.preventDefault(); // 폼의 기본 제출 동작 방지
 
-        const tripId = window.location.pathname.split('/').pop(); // URL에서 tripId 추출
+        // URL에서 tripId 추출
+        const tripId = window.location.pathname.split('/').pop();
         console.log('Extracted tripId:', tripId);
 
         // 여행 일정 데이터를 폼에서 가져오기
@@ -228,6 +231,7 @@
             tripDates: [] // tripDates 데이터는 필요에 따라 추가
         };
 
+        // 여행 날짜별 데이터 수집
         document.querySelectorAll('.trip-date').forEach(dateElement => {
             const tripDate = {
                 id: dateElement.dataset.id || null,
@@ -235,6 +239,7 @@
                 tripLocations: []
             };
 
+            // 각 장소에 대한 데이터 수집
             dateElement.querySelectorAll('.trip-location').forEach(locationElement => {
                 const tripLocation = {
                     id: locationElement.dataset.id || null,
@@ -248,6 +253,7 @@
             trip.tripDates.push(tripDate);
         });
 
+        // 서버에 여행 일정 수정 요청
         fetch(`/api/trips/${tripId}`, {
             method: 'PUT',
             headers: {
@@ -264,6 +270,11 @@
         });
     });
 
+    /**
+     * fetchTripData에서 호출되어 각 여행 날짜 동적으로 생성
+     * 여행 장소 상세는 createTripLocationHtml에서 생성
+     * @param tripDateData
+     */
     function addTripDate(tripDateData = {}) {
         const tripDateId = tripDatesCounter++;
         const tripDateElement = document.createElement('div');
@@ -284,6 +295,7 @@
 
         document.getElementById('tripDatesContainer').appendChild(tripDateElement);
 
+        // 받아온 데이터를 기반으로 selectedPlaces 객체 초기화
         const dayNum = tripDateId + 1;
         if (tripDateData.tripLocations) {
             selectedPlaces[dayNum] = tripDateData.tripLocations.map(loc => ({
@@ -294,6 +306,7 @@
 
             markers[dayNum] = [];
             tripDateData.tripLocations.forEach((loc) => {
+                // 받아온 데이터 기반으로 이미 추가되어있던 장소의 마커를 지도에 표시하기
                 addSavedPlacesMarker(loc.latitude, loc.longitude, markers[dayNum].length, dayNum);
                 // 폴리라인 그리기
                 drawLinePath(dayNum, new kakao.maps.LatLng(loc.latitude, loc.longitude));
@@ -305,19 +318,29 @@
         }
     }
 
+    /**
+     * 여행 장소 추가 함수
+     * @param button
+     * @returns {null|string}
+     */
     function addTripLocation(button) {
         document.getElementById('menu_wrap').style.display = 'block';
 
         selectedDateDiv = button.closest('.trip-date');
 
+        // 여행 몇째 날인지 추출 (ex. 1, 2, ..)
         if (selectedDateDiv) {
+            // Day 정보를 포함하는 span 요소 선택
             const dayCountSpan = selectedDateDiv.querySelector('.dayCountLabel');
 
             if (dayCountSpan) {
+                // "Day 1"과 같은 텍스트를 가져옴
                 const dayText = dayCountSpan.textContent.trim();
+                // "Day 1"에서 숫자 부분만 추출
                 const dayNum = dayText.replace('Day ', '');
-                reorderLocations();
+                // reorderLocations();
 
+                // selectedPlaces 객체에서 dayNum에 해당하는 배열이 없으면 초기화
                 if (!selectedPlaces[dayNum]) {
                     selectedPlaces[dayNum] = [];
                 }
@@ -326,7 +349,7 @@
                     markers[dayNum] = [];
                 }
 
-                return dayNum;
+                return dayNum;   // 예: "1"
             } else {
                 console.error('Day count span not found in selectedDateDiv.');
             }
@@ -336,46 +359,54 @@
         return null;
     }
 
-    function handleSelectCompleteBtnClick() {
-        if (selectedPlaces.length === 0) {
-            alert('선택된 장소가 없습니다. 장소를 추가해 주세요.');
-            return;
-        }
+    // function handleSelectCompleteBtnClick() {
+    //     if (selectedPlaces.length === 0) {
+    //         alert('선택된 장소가 없습니다. 장소를 추가해 주세요.');
+    //         return;
+    //     }
+    //
+    //     if (!selectedDateDiv) {
+    //         alert('장소를 추가할 날짜를 선택해 주세요.');
+    //         return;
+    //     }
+    //
+    //     const locationsContainer = selectedDateDiv.querySelector('.trip-locations');
+    //     selectedPlaces.forEach((place, index) => {
+    //         const tripLocationElement = document.createElement('div');
+    //         tripLocationElement.className = 'trip-location';
+    //         tripLocationElement.dataset.id = place.id || '';
+    //
+    //         const formattedLatitude = parseFloat(place.y).toFixed(6);
+    //         const formattedLongitude = parseFloat(place.x).toFixed(6);
+    //
+    //         tripLocationElement.innerHTML = `
+    //         <div class="placeNameContainer">
+    //             <span id="${uniqueId}" style="color: ${getColorCode(index)};">${index + 1}</span>
+    //             <input type="text" class="placeNameInput" value="${place.place_name}" readonly />
+    //         </div>
+    //         <input type="hidden" class="longitudeInput" value="${formattedLongitude}" />
+    //         <input type="hidden" class="latitudeInput" value="${formattedLatitude}" />
+    //     `;
+    //
+    //         locationsContainer.appendChild(tripLocationElement);
+    //         reorderLocations();
+    //     });
+    //
+    //     selectedPlaces = [];
+    //     selectedDateDiv = null;
+    //     $('#menu_wrap').hide();
+    //
+    // }
 
-        if (!selectedDateDiv) {
-            alert('장소를 추가할 날짜를 선택해 주세요.');
-            return;
-        }
-
-        const locationsContainer = selectedDateDiv.querySelector('.trip-locations');
-        selectedPlaces.forEach((place, index) => {
-            const tripLocationElement = document.createElement('div');
-            tripLocationElement.className = 'trip-location';
-            tripLocationElement.dataset.id = place.id || '';
-
-            const formattedLatitude = parseFloat(place.y).toFixed(6);
-            const formattedLongitude = parseFloat(place.x).toFixed(6);
-
-            tripLocationElement.innerHTML = `
-            <div class="placeNameContainer">
-                <span id="${uniqueId}" style="color: ${getColorCode(index)};">${index + 1}</span>
-                <input type="text" class="placeNameInput" value="${place.place_name}" readonly />
-            </div>
-            <input type="hidden" class="longitudeInput" value="${formattedLongitude}" />
-            <input type="hidden" class="latitudeInput" value="${formattedLatitude}" />
-        `;
-
-            locationsContainer.appendChild(tripLocationElement);
-            reorderLocations();
-        });
-
-        selectedPlaces = [];
-        selectedDateDiv = null;
-        $('#menu_wrap').hide();
-
-    }
-
+    /**
+     * 여행 장소 상세 HTML 생성
+     * @param tripLocationData
+     * @param dayNum
+     * @param placeIndex
+     * @returns {string}
+     */
     function createTripLocationHtml(tripLocationData, dayNum, placeIndex) {
+        // 장소의 고유 ID 생성 (ex. 몇일차-몇번째장소: 1-1, 1-2, 2-1, ..)
         const uniqueId = `${dayNum}-${placeIndex}`;
         const markerImageIndex = (dayNum % 6) === 0 ? 6 : (dayNum % 6);
         const colorCode = getColorCode(markerImageIndex);
@@ -394,7 +425,11 @@
     }
 
 
+    /**
+     * 여행 데이터 가져와서 HTML에 채워넣기
+     */
     function fetchTripData() {
+        // tripId를 사용하여 서버에서 여행 데이터를 가져옴
         fetch(`/api/trips/${tripId}`)
             .then(response => response.json())
             .then(trip => {
@@ -402,30 +437,38 @@
                 document.getElementById('startDate').value = trip.startDate;
                 document.getElementById('endDate').value = trip.endDate;
 
+                // 각 여행 날짜에 대한 정보를 추가
                 trip.tripDates.forEach(tripDate => addTripDate(tripDate));
                 reorderLocations();
             });
     }
 
+    // function reorderLocations() {
+    //     // 각 날짜의 .trip-date 요소를 순회
+    //     document.querySelectorAll('.trip-date').forEach((dateElement) => {
+    //         let locationCounter = 1; // 각 날짜의 장소 번호를 1부터 시작
+    //         // 해당 날짜의 모든 .trip-location 요소를 순회하며 번호를 재정렬
+    //         dateElement.querySelectorAll('.trip-location').forEach((locationElement) => {
+    //             const placeNumberElement = locationElement.querySelector('span');
+    //             if (placeNumberElement) {
+    //                 placeNumberElement.textContent = locationCounter++; // 번호 갱신
+    //             } else {
+    //                 // 만약 'span' 요소가 없다면 새로 생성해서 추가
+    //                 const newPlaceNumberElement = document.createElement('span');
+    //                 newPlaceNumberElement.textContent = locationCounter++;
+    //                 locationElement.insertBefore(newPlaceNumberElement, locationElement.firstChild);
+    //             }
+    //         });
+    //     });
+    // }
+
     function reorderLocations() {
-        // 각 날짜의 .trip-date 요소를 순회
-        document.querySelectorAll('.trip-date').forEach((dateElement) => {
-            let locationCounter = 1; // 각 날짜의 장소 번호를 1부터 시작
-            // 해당 날짜의 모든 .trip-location 요소를 순회하며 번호를 재정렬
-            dateElement.querySelectorAll('.trip-location').forEach((locationElement) => {
-                const placeNumberElement = locationElement.querySelector('span');
-                if (placeNumberElement) {
-                    placeNumberElement.textContent = locationCounter++; // 번호 갱신
-                } else {
-                    // 만약 'span' 요소가 없다면 새로 생성해서 추가
-                    const newPlaceNumberElement = document.createElement('span');
-                    newPlaceNumberElement.textContent = locationCounter++;
-                    locationElement.insertBefore(newPlaceNumberElement, locationElement.firstChild);
-                }
-            });
-        });
+
     }
 
+    /**
+     * 날짜 카운트 업데이트 (Day 숫자 업데이트)
+     */
     function updateDayCount() {
         const tripDateInputs = document.querySelectorAll('.tripDateInput');
         tripDateInputs.forEach((input, index) => {
@@ -441,14 +484,21 @@
         });
     }
 
+    // 페이지 로드 시 여행 데이터를 가져옴
     const tripId = window.location.pathname.split('/').pop();
     fetchTripData();
 
+    // 창 닫기 버튼 클릭 시 #menu_wrap 숨기기
     document.getElementById('closeBtn').addEventListener('click', function() {
         $('#menu_wrap').hide();
     });
 
+    /**
+     * 날짜 변경 시 일정을 조정하는 함수
+     */
     function updateTripDates() {
+        tripDatesCounter = 0;
+
         const startDate = new Date(document.getElementById('startDate').value);
         const endDate = new Date(document.getElementById('endDate').value);
 
@@ -457,28 +507,41 @@
             return;
         }
 
+        // 현재 화면에 표시된 여행 날짜 데이터와 속한 장소 데이터를 existingTripDates 배열에 저장
         const existingTripDates = document.querySelectorAll('.trip-date');
+        // 기존의 trip-date 요소를 모두 선택하여 배열로 변환
         const existingTripData = Array.from(existingTripDates).map((dateElement, index) => {
+            // 각 trip-date 요소에서 여행 장소를 배열로 수집
             const tripLocations = Array.from(dateElement.querySelectorAll('.trip-location')).map(locationElement => ({
                 placeName: locationElement.querySelector('.placeNameInput').value,
                 latitude: parseFloat(locationElement.querySelector('.latitudeInput').value),
                 longitude: parseFloat(locationElement.querySelector('.longitudeInput').value)
             }));
 
+            // 여행 날짜와 장소들을 객체로 반환
             return {
                 tripDate: dateElement.querySelector('.tripDateInput').value,
                 tripLocations
             };
         });
 
+        // 새로운 날짜 범위에 따라 addTripDate()를 사용해 화면에 새로운 여행 날짜 추가 후 해당 날짜에 맞는 기존 데이터를 매칭해 설정
         const newTripDatesContainer = document.getElementById('tripDatesContainer');
+        // 새로운 여행 날짜를 표시할 컨테이너를 선택하고 기존 내용을 비움
         newTripDatesContainer.innerHTML = '';
 
+        // selectedPlaces와 markers의 기존 데이터들을 비워줌
+        selectedPlaces = {};
+        markers = {};
+
         let newDateIndex = 0;
+        // 시작 날짜부터 종료 날짜까지 반복하며 날짜를 생성
         for (let date = new Date(startDate); date <= endDate; date.setDate(date.getDate() + 1)) {
+            // 현재 날짜에 해당하는 기존 여행 데이터가 있으면 가져옴, 없으면 빈 객체 사용
             const tripDateData = existingTripData[newDateIndex] || {};
             const dayNum = newDateIndex + 1;
 
+            // 기존 addTripDate 함수 호출하여 새로운 날짜를 추가
             addTripDate({
                 tripDate: date.toISOString().split('T')[0],
                 tripLocations: tripDateData.tripLocations || []
@@ -487,6 +550,7 @@
             newDateIndex++;
         }
 
+        // 만약 새로운 날짜 범위가 기존 날짜보다 짧다면, 남는 날짜의 장소들을 마지막 날로 합침
         if (newDateIndex < existingTripData.length) {
             const lastTripLocations = existingTripData.slice(newDateIndex).flatMap(data => data.tripLocations);
             const lastDayElement = newTripDatesContainer.querySelector('.trip-date:last-child .trip-locations');
@@ -496,7 +560,7 @@
         }
 
         updateDayCount();
-        reorderLocations();
+        // reorderLocations();
     }
 
     document.getElementById('startDate').addEventListener('change', updateTripDates);

--- a/src/main/resources/templates/trip/updatetrip.html
+++ b/src/main/resources/templates/trip/updatetrip.html
@@ -525,6 +525,8 @@
             };
         });
 
+        console.log('existingTripData --- {}', existingTripData);
+
         // 새로운 날짜 범위에 따라 addTripDate()를 사용해 화면에 새로운 여행 날짜 추가 후 해당 날짜에 맞는 기존 데이터를 매칭해 설정
         const newTripDatesContainer = document.getElementById('tripDatesContainer');
         // 새로운 여행 날짜를 표시할 컨테이너를 선택하고 기존 내용을 비움
@@ -552,15 +554,53 @@
             });
 
             newDateIndex++;
+
+            console.log('tripDateData --- {}', tripDateData);
+            console.log('newDateIndex --- ', newDateIndex);
+            console.log('existingTripData.length --- ', existingTripData.length);
+
         }
 
         // 만약 새로운 날짜 범위가 기존 날짜보다 짧다면, 남는 날짜의 장소들을 마지막 날로 합침
         if (newDateIndex < existingTripData.length) {
-            const lastTripLocations = existingTripData.slice(newDateIndex).flatMap(data => data.tripLocations);
+            // 새로운 날짜 범위에 포함되지 않는 남은 날짜들(existingTripData[newDateIndex] 이후)에 있는 모든 장소들을 모아서 lastTripLocations에 저장
+            const lastTripLocations = existingTripData
+                .slice(newDateIndex)    // 기존 데이터에서 새로운 날짜 범위 이후의 데이터를 잘라냄
+                .flatMap(data => data.tripLocations);   // 잘라낸 데이터에서 각 날짜의 장소들(tripLocations)을 추출하여 하나의 배열로 만듦
+
+            // 새로운 날짜 범위에서 마지막 날에 해당하는 trip-locations 요소를 찾음
             const lastDayElement = newTripDatesContainer.querySelector('.trip-date:last-child .trip-locations');
+
+            // 남은 날짜들의 장소들(lastTripLocations)을 하나씩 마지막 날에 추가
             lastTripLocations.forEach((loc, index) => {
-                lastDayElement.insertAdjacentHTML('beforeend', createTripLocationHtml(loc, newDateIndex + 1, index + 1));
+                lastDayElement.insertAdjacentHTML(
+                    'beforeend',    // lastDayElement의 마지막 자식 요소로 새로운 장소 요소를 추가
+                    createTripLocationHtml(loc, newDateIndex, existingTripData.length + index + 1)  // 남은 날짜의 장소(loc)를 HTML로 생성하여 추가
+                    // newDateIndex은 장소 uniqueId의 dayNum이 되고, existingTripData.length + index + 1은 장소 순서가 됨(lastTripLocations의 index는 0부터 시작하므로 +1 해줌)
+                );
+
+                // 선택된 장소들을 저장해둔 selectedPlaces 객체에 데이터 추가
+                if (!selectedPlaces[newDateIndex]) {
+                    selectedPlaces[newDateIndex] = [];
+                }
+                selectedPlaces[newDateIndex].push({
+                    placeName: loc.placeName,
+                    latitude: loc.latitude,
+                    longitude: loc.longitude
+                });
+
+                // 지도에 장소들을 제대로 표시하기 위해 아래 함수들 실행
+                // 지도에 마커 추가
+                const placePosition = new kakao.maps.LatLng(loc.latitude, loc.longitude);
+                addSelectedMarker(placePosition, existingTripData.length + index + 1, newDateIndex);
+                // 마커 번호 재정렬
+                reorderMarkers(markers, newDateIndex);
+                // 지도 범위 재설정
+                setBounds(placePosition);
+                // 지도에 선 표시
+                drawLinePath(newDateIndex, placePosition);
             });
+
         }
 
         updateDayCount();

--- a/src/main/resources/templates/trip/updatetrip.html
+++ b/src/main/resources/templates/trip/updatetrip.html
@@ -604,6 +604,8 @@
         }
 
         updateDayCount();
+        // 날짜 변경 시 날짜 변경 전에 띄워둔 검색창 숨기기
+        $('#menu_wrap').hide();
         // reorderLocations();
     }
 

--- a/src/main/resources/templates/trip/updatetrip.html
+++ b/src/main/resources/templates/trip/updatetrip.html
@@ -210,7 +210,7 @@
     };
 
     let tripDatesCounter = 0;
-    let markers = {};   // 마커를 저장할 객체
+    let markers = {};   // 마커를 저장할 객체 (key: dayNum, value: marker 객체 배열)
     let selectedPlaces = {};    // 선택된 장소를 저장할 객체
     let selectedDateDiv = null; // 선택된 날짜의 div 요소
 
@@ -530,9 +530,13 @@
         // 새로운 여행 날짜를 표시할 컨테이너를 선택하고 기존 내용을 비움
         newTripDatesContainer.innerHTML = '';
 
-        // selectedPlaces와 markers의 기존 데이터들을 비워줌
+        // addTripDate() 호출 전 기존 데이터들 모두 지우기
+        // 추가된 장소 배열인 selectedPlaces 객체 & 폴리라인을 구성하는 좌표 배열인 linePath 객체를 초기화시킴
         selectedPlaces = {};
-        markers = {};
+        linePath = {};
+        // 지도 위에 표시되고 있는 마커와 폴리라인을 제거
+        clearAllMarker();
+        clearAllPolyline();
 
         let newDateIndex = 0;
         // 시작 날짜부터 종료 날짜까지 반복하며 날짜를 생성

--- a/src/main/resources/templates/trip/updatetrip.html
+++ b/src/main/resources/templates/trip/updatetrip.html
@@ -571,8 +571,16 @@
             // 새로운 날짜 범위에서 마지막 날에 해당하는 trip-locations 요소를 찾음
             const lastDayElement = newTripDatesContainer.querySelector('.trip-date:last-child .trip-locations');
 
+            // 하루에 추가할 수 있는 장소는 최대 15개이기 때문에 합쳤을 때 15개를 초과하는 장소들은 잘라내야 함
+            // 현재 마지막 날에 이미 있는 장소 개수
+            const currentLastDayLocationsCount = lastDayElement.querySelectorAll('.trip-location').length;
+            // 추가할 수 있는 최대 장소 개수 (15 - 새로운 날짜 범위에 포함되지 않는 날짜들에 있는 장소들의 개수 - 마지막 날에 이미 있는 장소 개수)
+            const maxAddLocations = MAX_LOCATIONS - lastTripLocations.length - currentLastDayLocationsCount;
+            // 남은 장소들 중 추가할 수 있는 최대 개수만큼 잘라냄
+            const LocationsToAdd = lastTripLocations.slice(0, maxAddLocations);
+
             // 남은 날짜들의 장소들(lastTripLocations)을 하나씩 마지막 날에 추가
-            lastTripLocations.forEach((loc, index) => {
+            LocationsToAdd.forEach((loc, index) => {
                 lastDayElement.insertAdjacentHTML(
                     'beforeend',    // lastDayElement의 마지막 자식 요소로 새로운 장소 요소를 추가
                     createTripLocationHtml(loc, newDateIndex, existingTripData.length + index + 1)  // 남은 날짜의 장소(loc)를 HTML로 생성하여 추가


### PR DESCRIPTION
### 설명
- 매개변수 이름 인식 문제 해결 위해 컴파일 옵션 변경하는 build.gradle을 추가했습니다.
- 일정 생성, 수정 페이지에서 날짜 변경 시 장소 순서와 지도 표시를 알맞게 수정했습니다.
- 일정 수정 페이지에서 날짜 변경 시 남는 날짜의 장소들을 마지막 날로 합칠 때, 장소의 개수가 15개를 초과하면 초과된 장소는 제외 후 합치도록 변경했습니다.
- 여행 일정 수정 페이지에서 가끔 데이터 못 읽어오는 문제를 해결했습니다.
  - 못 읽어올 때 콘솔에 찍히는 걸 보니 스크립트 로딩 및 실행 순서와 관련이 있었음.
  - `Uncaught (in promise) ReferenceError: getColorCode is not defined at createTripLocationHtml` 이런식으로 찍혔음.
  - script 태그에 defer 속성을 추가해서 HTML 문서 파싱이 끝난 후 스크립트가 실행되도록 변경했음.

### 관련 이슈
Closes #146
Closes #149  

### 변경 유형
- [x] 버그 수정
- [x] 새로운 기능
- [x] 코드 개선
- [x] 문서 업데이트

### 체크리스트
- [x] 이 프로젝트의 코딩 스타일 가이드를 준수했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 문서에 변경 사항을 반영했습니다.
- [x] 새로운 경고를 생성하지 않습니다.
- [ ] 변경 사항이 효과적임을 증명하는 테스트를 추가했습니다.
- [x] 새로운 기능이나 수정 사항이 기존 테스트와 충돌하지 않음을 확인했습니다.

### 추가 설명

